### PR TITLE
[TASK] Change project vendor to "cpsit"

### DIFF
--- a/Documentation/install.md
+++ b/Documentation/install.md
@@ -9,7 +9,7 @@
 ## Composer
 
 ```bash
-composer require fr/typo3-handlebars
+composer require cpsit/typo3-handlebars
 ```
 
 ## Define dependencies

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-	"name": "fr/typo3-handlebars",
+	"name": "cpsit/typo3-handlebars",
 	"type": "typo3-cms-extension",
 	"description": "Handlebars rendering for projects built with TYPO3 CMS",
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION
This PR changes the projects' vendor name `fr` to `cpsit`. This is required since the vendor `fr` is already claimed by somebody else on Packagist. 