### PR TITLE
[!!!][FEATURE] Introduce autoconfiguration for Handlebars helpers at all Helper-aware renderers

### DIFF
--- a/Classes/DependencyInjection/HandlebarsHelperPass.php
+++ b/Classes/DependencyInjection/HandlebarsHelperPass.php
@@ -23,9 +23,10 @@ declare(strict_types=1);
 
 namespace Fr\Typo3Handlebars\DependencyInjection;
 
-use Fr\Typo3Handlebars\Renderer\HandlebarsRenderer;
+use Fr\Typo3Handlebars\Renderer\HelperAwareInterface;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
 
 /**
  * HandlebarsHelperPass
@@ -39,48 +40,79 @@ final class HandlebarsHelperPass implements CompilerPassInterface
     /**
      * @var string
      */
-    private $tagName;
+    private $helperTagName;
 
     /**
      * @var string
      */
-    private $rendererServiceId;
+    private $rendererTagName;
 
-    public function __construct(string $tagName, string $rendererId = HandlebarsRenderer::class)
+    /**
+     * @var Definition[]
+     */
+    private $rendererDefinitions = [];
+
+    public function __construct(string $helperTagName, string $rendererTagName)
     {
-        $this->tagName = $tagName;
-        $this->rendererServiceId = $rendererId;
+        $this->helperTagName = $helperTagName;
+        $this->rendererTagName = $rendererTagName;
     }
 
     public function process(ContainerBuilder $container): void
     {
-        $handlebarsRendererDefinition = $container->findDefinition($this->rendererServiceId);
+        $this->fetchRendererDefinitions($container);
 
-        foreach ($container->findTaggedServiceIds($this->tagName) as $serviceName => $tags) {
-            $container->findDefinition($serviceName)->setPublic(true);
+        // Register tagged Handlebars helper at all Helper-aware renderers
+        foreach ($container->findTaggedServiceIds($this->helperTagName) as $serviceId => $tags) {
+            $container->findDefinition($serviceId)->setPublic(true);
 
             foreach (array_filter($tags) as $attributes) {
-                if (!array_key_exists('identifier', $attributes) || (string)$attributes['identifier'] === '') {
-                    throw new \InvalidArgumentException(
-                        'Service tag "' . $this->tagName . '" requires an identifier attribute to be defined, missing in: ' . $serviceName,
-                        1606236820
-                    );
-                }
-                if (!array_key_exists('method', $attributes) || (string)$attributes['method'] === '') {
-                    throw new \InvalidArgumentException(
-                        'Service tag "' . $this->tagName . '" requires an method attribute to be defined, missing in: ' . $serviceName,
-                        1606245140
-                    );
-                }
-
-                // Register Handlebars helpers globally
-                $identifier = $attributes['identifier'];
-                $method = $attributes['method'];
-                $handlebarsRendererDefinition->addMethodCall('registerHelper', [
-                    $identifier,
-                    $serviceName . '::' . $method,
-                ]);
+                $this->validateTag($serviceId, $attributes);
+                $this->registerHelper(
+                    $attributes['identifier'],
+                    sprintf('%s::%s', $serviceId, $attributes['method'])
+                );
             }
+        }
+    }
+
+    private function registerHelper(string $name, string $function): void
+    {
+        foreach ($this->rendererDefinitions as $rendererDefinition) {
+            $rendererDefinition->addMethodCall('registerHelper', [$name, $function]);
+        }
+    }
+
+    protected function fetchRendererDefinitions(ContainerBuilder $container): void
+    {
+        $this->rendererDefinitions = [];
+
+        foreach (array_keys($container->findTaggedServiceIds($this->rendererTagName)) as $serviceId) {
+            $rendererDefinition = $container->findDefinition($serviceId);
+
+            if (in_array(HelperAwareInterface::class, class_implements($rendererDefinition->getClass()))) {
+                $this->rendererDefinitions[] = $rendererDefinition;
+            }
+        }
+    }
+
+    /**
+     * @param string $serviceId
+     * @param array<string, string> $tagAttributes
+     */
+    private function validateTag(string $serviceId, array $tagAttributes): void
+    {
+        if (!array_key_exists('identifier', $tagAttributes) || '' === (string)$tagAttributes['identifier']) {
+            throw new \InvalidArgumentException(
+                sprintf('Service tag "%s" requires an identifier attribute to be defined, missing in: %s', $this->helperTagName, $serviceId),
+                1606236820
+            );
+        }
+        if (!array_key_exists('method', $tagAttributes) || '' === (string)$tagAttributes['method']) {
+            throw new \InvalidArgumentException(
+                sprintf('Service tag "%s" requires an method attribute to be defined, missing in: %s', $this->helperTagName, $serviceId),
+                1606245140
+            );
         }
     }
 }

--- a/Classes/Renderer/HandlebarsRenderer.php
+++ b/Classes/Renderer/HandlebarsRenderer.php
@@ -47,7 +47,7 @@ use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
  * @author Elias Häußler <e.haeussler@familie-redlich.de>
  * @license GPL-2.0-or-later
  */
-class HandlebarsRenderer implements RendererInterface, LoggerAwareInterface
+class HandlebarsRenderer implements RendererInterface, HelperAwareInterface, LoggerAwareInterface
 {
     use HandlebarsHelperTrait;
     use LoggerAwareTrait;

--- a/Classes/Renderer/HelperAwareInterface.php
+++ b/Classes/Renderer/HelperAwareInterface.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "handlebars".
+ *
+ * Copyright (C) 2021 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace Fr\Typo3Handlebars\Renderer;
+
+/**
+ * HelperAwareInterface
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-2.0-or-later
+ */
+interface HelperAwareInterface
+{
+    /**
+     * Get all registered Handlebars helpers.
+     *
+     * @return array<string, callable>
+     */
+    public function getHelpers(): array;
+
+    /**
+     * Register new Handlebars helper with given function.
+     *
+     * @param string $name
+     * @param mixed $function
+     */
+    public function registerHelper(string $name, $function): void;
+}

--- a/Classes/Traits/HandlebarsHelperTrait.php
+++ b/Classes/Traits/HandlebarsHelperTrait.php
@@ -42,21 +42,28 @@ trait HandlebarsHelperTrait
     /**
      * @param string $name
      * @param mixed $function
-     * @return self
      */
-    public function registerHelper(string $name, $function): self
+    public function registerHelper(string $name, $function): void
     {
-        if (!$this->isValidHelper($function)) {
-            if ($this->logger instanceof LoggerInterface) {
-                $this->logger->critical(
-                    'Error while registering Handlebars helper "' . $name . '".',
-                    ['name' => $name, 'function' => $function]
-                );
-            }
-            return $this;
+        if ($this->isValidHelper($function)) {
+            $this->helpers[$name] = $this->resolveHelperFunction($function);
+            return;
         }
-        $this->helpers[$name] = $this->resolveHelperFunction($function);
-        return $this;
+
+        if ($this->logger instanceof LoggerInterface) {
+            $this->logger->critical(
+                'Error while registering Handlebars helper "' . $name . '".',
+                ['name' => $name, 'function' => $function]
+            );
+        }
+    }
+
+    /**
+     * @return array<string, callable>
+     */
+    public function getHelpers(): array
+    {
+        return $this->helpers;
     }
 
     /**

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -17,6 +17,7 @@ services:
       $partialResolver: '@handlebars.partial_resolver'
       $cache: '@handlebars.cache'
       $defaultData: '%handlebars.default_data%'
+    tags: ['handlebars.renderer']
 
   Fr\Typo3Handlebars\Renderer\RendererInterface:
     alias: 'handlebars.renderer'

--- a/Documentation/Usage/Extended/CustomRenderingComponents/Index.rst
+++ b/Documentation/Usage/Extended/CustomRenderingComponents/Index.rst
@@ -20,6 +20,12 @@ describes a `Renderer`. A distinction must be made as to whether the
 custom `Renderer` is to be used for all components or only for individual
 variants.
 
+.. important::
+
+   If you want your custom `Renderer` to be autoconfigured with all globally
+   registered `Helpers`, make sure to tag it with `handlebars.renderer` and
+   implement the interface :php:`Fr\Typo3Handlebars\Renderer\HelperAwareInterface`.
+
 .. _global-replacement:
 
 Global replacement
@@ -136,5 +142,5 @@ Sources
    View the sources on GitHub:
 
    -  `RendererInterface <https://github.com/CPS-IT/handlebars/blob/master/Classes/Renderer/RendererInterface.php>`__
+   -  `HelperAwareInterface <https://github.com/CPS-IT/handlebars/blob/master/Classes/Renderer/HelperAwareInterface.php>`__
    -  `TemplateResolverInterface <https://github.com/CPS-IT/handlebars/blob/master/Classes/Renderer/Template/TemplateResolverInterface.php>`__
-

--- a/Tests/Unit/Fixtures/Classes/Traits/DummyHandlebarsHelperTraitClass.php
+++ b/Tests/Unit/Fixtures/Classes/Traits/DummyHandlebarsHelperTraitClass.php
@@ -36,12 +36,4 @@ final class DummyHandlebarsHelperTraitClass
 {
     use HandlebarsHelperTrait;
     use LoggerAwareTrait;
-
-    /**
-     * @return array<string, string>
-     */
-    public function getHelpers(): array
-    {
-        return $this->helpers;
-    }
 }

--- a/Tests/Unit/Traits/HandlebarsHelperTraitTest.php
+++ b/Tests/Unit/Traits/HandlebarsHelperTraitTest.php
@@ -97,6 +97,17 @@ class HandlebarsHelperTraitTest extends UnitTestCase
     }
 
     /**
+     * @test
+     */
+    public function getHelpersReturnsRegisteredHelpers(): void
+    {
+        self::assertSame([], $this->subject->getHelpers());
+
+        $this->subject->registerHelper('foo', 'strtolower');
+        self::assertSame(['foo' => 'strtolower'], $this->subject->getHelpers());
+    }
+
+    /**
      * @return \Generator<string, array>
      */
     public function registerHelperLogsCriticalErrorIfGivenHelperIsInvalidDataProvider(): \Generator


### PR DESCRIPTION
This PR introduces a new `HelperAwareInterface` that can be used to identify those Handlebars renderers that should be auto-configured by all globally registered Handlebars helpers. To achieve this goal, a new service tag `handlebars.renderer` has been introduced.