### PR TITLE
[TASK] Add TYPO3 11.4 to GitHub test workflow

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,9 +13,9 @@ jobs:
             php-version: 7.3
           - typo3-version: 10.4
             php-version: 7.4
-          - typo3-version: 11.3
+          - typo3-version: 11.4
             php-version: 7.4
-          - typo3-version: 11.3
+          - typo3-version: 11.4
             php-version: 8.0
             coverage: 1
     steps:
@@ -75,9 +75,9 @@ jobs:
             php-version: 7.3
           - typo3-version: 10.4
             php-version: 7.4
-          - typo3-version: 11.3
+          - typo3-version: 11.4
             php-version: 7.4
-          - typo3-version: 11.3
+          - typo3-version: 11.4
             php-version: 8.0
     steps:
       - uses: actions/checkout@v2

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
 		"saschaegerer/phpstan-typo3": "^0.13",
 		"symfony/event-dispatcher": "^4.4 || ^5.0",
 		"typo3/coding-standards": "^0.3.0",
-		"typo3/testing-framework": "^6.8"
+		"typo3/testing-framework": "^6.10"
 	},
 	"config": {
 		"bin-dir": ".Build/bin",


### PR DESCRIPTION
This PR changes GitHub test workflow to use TYPO3 11.4 instead of 11.3.