### PR TITLE
[TASK] Add setter for $cObj in AbstractDataProcessor

### DIFF
--- a/Classes/DataProcessing/AbstractDataProcessor.php
+++ b/Classes/DataProcessing/AbstractDataProcessor.php
@@ -102,6 +102,12 @@ abstract class AbstractDataProcessor implements DataProcessorInterface, LoggerAw
         return $this;
     }
 
+    public function setContentObjectRenderer(ContentObjectRenderer $cObj): self
+    {
+        $this->cObj = $cObj;
+        return $this;
+    }
+
     /**
      * Process and render data.
      *


### PR DESCRIPTION
Since TYPO3 11.4 and https://forge.typo3.org/issues/94956 the use of the public property `$cObj` in data processors is deprecated. As a replacement, a public setter `setContentObjectRenderer` should be used. This commit adds this setter but keeps the public property as-is to assure compatibility with TYPO3 < 11.4.