### PR TITLE
[!!!][FEATURE] Allow TypoScript as configuration for template paths

### DIFF
--- a/Classes/Renderer/Template/HandlebarsTemplateResolver.php
+++ b/Classes/Renderer/Template/HandlebarsTemplateResolver.php
@@ -48,12 +48,12 @@ class HandlebarsTemplateResolver implements TemplateResolverInterface
     protected $supportedFileExtensions;
 
     /**
-     * @param string[] $templateRootPaths
+     * @param TemplatePaths $templateRootPaths
      * @param string[] $supportedFileExtensions
      */
-    public function __construct(array $templateRootPaths, array $supportedFileExtensions = self::DEFAULT_FILE_EXTENSIONS)
+    public function __construct(TemplatePaths $templateRootPaths, array $supportedFileExtensions = self::DEFAULT_FILE_EXTENSIONS)
     {
-        $this->setTemplateRootPaths($templateRootPaths);
+        $this->setTemplateRootPaths($templateRootPaths->get());
         $this->setSupportedFileExtensions($supportedFileExtensions);
     }
 
@@ -69,7 +69,7 @@ class HandlebarsTemplateResolver implements TemplateResolverInterface
      * Set sorted list of template root paths.
      *
      * Sorts the given template root paths by array key and applies them to the resolver.
-     * Addtionally, trailing directory separators are stripped of to normalize paths and
+     * Additionally, trailing directory separators are stripped of to normalize paths and
      * allow less error-prone template path resolving.
      *
      * @param string[] $templateRootPaths List of (probably unsorted) template root paths

--- a/Classes/Renderer/Template/TemplatePaths.php
+++ b/Classes/Renderer/Template/TemplatePaths.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "handlebars".
+ *
+ * Copyright (C) 2021 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace Fr\Typo3Handlebars\Renderer\Template;
+
+use Fr\Typo3Handlebars\Configuration\Extension;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
+
+/**
+ * TemplatePaths
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-2.0-or-later
+ */
+class TemplatePaths implements ContainerAwareInterface
+{
+    use ContainerAwareTrait;
+
+    public const TEMPLATES = 'template_root_paths';
+    public const PARTIALS = 'partial_root_paths';
+
+    /**
+     * @var ConfigurationManagerInterface
+     */
+    protected $configurationManager;
+
+    /**
+     * @var string
+     */
+    protected $type;
+
+    /**
+     * @var string[]
+     */
+    protected $templatePaths;
+
+    /**
+     * @param ConfigurationManagerInterface $configurationManager
+     * @param string $type
+     */
+    public function __construct(ConfigurationManagerInterface $configurationManager, string $type = self::TEMPLATES)
+    {
+        $this->configurationManager = $configurationManager;
+        $this->type = $type;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function get(): array
+    {
+        if (null === $this->templatePaths) {
+            $this->resolveTemplatePaths();
+        }
+
+        return $this->templatePaths;
+    }
+
+    protected function resolveTemplatePaths(): void
+    {
+        $this->templatePaths = $this->mergeTemplatePaths(
+            $this->getTemplatePathsFromContainer($this->type),
+            $this->getTemplatePathsFromTypoScriptConfiguration($this->type)
+        );
+    }
+
+    /**
+     * @param string $type
+     * @return string[]
+     */
+    protected function getTemplatePathsFromContainer(string $type): array
+    {
+        $parameterName = 'handlebars.' . $type;
+
+        return $this->container->getParameter($parameterName);
+    }
+
+    /**
+     * @param string $type
+     * @return string[]
+     */
+    protected function getTemplatePathsFromTypoScriptConfiguration(string $type): array
+    {
+        $configurationType = GeneralUtility::underscoredToLowerCamelCase($type);
+        $typoScriptConfiguration = $this->configurationManager->getConfiguration(
+            ConfigurationManagerInterface::CONFIGURATION_TYPE_FRAMEWORK,
+            Extension::NAME
+        );
+
+        return $typoScriptConfiguration['view'][$configurationType] ?? [];
+    }
+
+    /**
+     * @param string[] ...$templatePaths
+     * @return string[]
+     */
+    protected function mergeTemplatePaths(array ...$templatePaths): array
+    {
+        $mergedTemplatePaths = array_replace(...$templatePaths);
+        ksort($mergedTemplatePaths);
+
+        return $mergedTemplatePaths;
+    }
+}

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -25,15 +25,28 @@ services:
   handlebars.template_resolver:
     class: 'Fr\Typo3Handlebars\Renderer\Template\HandlebarsTemplateResolver'
     arguments:
-      $templateRootPaths: '%handlebars.template_root_paths%'
+      $templateRootPaths: '@handlebars.template_paths.template_root_paths'
 
   handlebars.partial_resolver:
     class: 'Fr\Typo3Handlebars\Renderer\Template\HandlebarsTemplateResolver'
     arguments:
-      $templateRootPaths: '%handlebars.partial_root_paths%'
+      $templateRootPaths: '@handlebars.template_paths.partial_root_paths'
 
   Fr\Typo3Handlebars\Renderer\Template\TemplateResolverInterface:
     alias: 'handlebars.template_resolver'
+
+  handlebars.template_paths:
+    class: 'Fr\Typo3Handlebars\Renderer\Template\TemplatePaths'
+    calls:
+      - setContainer: ['@service_container']
+  handlebars.template_paths.template_root_paths:
+    parent: 'handlebars.template_paths'
+    arguments:
+      $type: 'template_root_paths'
+  handlebars.template_paths.partial_root_paths:
+    parent: 'handlebars.template_paths'
+    arguments:
+      $type: 'partial_root_paths'
 
   # Data processor
   Fr\Typo3Handlebars\DataProcessing\SimpleProcessor:

--- a/Documentation/Configuration/TemplatePaths/Index.rst
+++ b/Documentation/Configuration/TemplatePaths/Index.rst
@@ -6,13 +6,21 @@
 Template paths
 ==============
 
+There exist several ways to declare template root paths and partial root
+paths. The most relevant ones are described below.
+
+.. _configuration-via-service-container:
+
+Configuration via service container
+===================================
+
 .. attention::
 
    Make sure you have defined :ref:`EXT:handlebars as dependency <define-dependencies>`
    in your extension(s). Otherwise, template root paths might not be interpreted correctly.
 
-Registration of template root paths and partial root paths is done within
-the :file:`Services.yaml` file:
+The easiest way to register your template root paths and partial root paths
+is by using the :file:`Services.yaml` file:
 
 .. code-block:: yaml
 
@@ -34,6 +42,35 @@ service container resulting in the following parameters:
 
 You can reference those parameters in your custom configuration to use the
 resolved template paths in your services.
+
+The drawback of this configuration is that it is applied to the whole TYPO3
+instance since there exists only one service container for the whole system.
+In case you need different template paths for specific parts of your
+installation, take a look at the following configuration method that uses
+TypoScript.
+
+.. _configuration-via-typoscript:
+
+Configuration via TypoScript
+============================
+
+A more flexible configuration method is the usage of TypoScript. This way you
+can override the configuration from the service container (as described above)
+which allows you to define different template root paths and partial root
+paths for specific parts of the system.
+
+.. code-block:: typoscript
+
+   plugin.tx_handlebars {
+     view {
+       templateRootPaths {
+         20 = EXT:my_other_extension/Resources/Private/Templates
+       }
+       partialRootPaths {
+         20 = EXT:my_other_extension/Resources/Private/Partials
+       }
+     }
+   }
 
 .. note::
 

--- a/Tests/Unit/Fixtures/Classes/DummyConfigurationManager.php
+++ b/Tests/Unit/Fixtures/Classes/DummyConfigurationManager.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "handlebars".
+ *
+ * Copyright (C) 2021 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace Fr\Typo3Handlebars\Tests\Unit\Fixtures\Classes;
+
+use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
+use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
+
+/**
+ * DummyConfigurationManager
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-2.0-or-later
+ * @internal
+ */
+final class DummyConfigurationManager implements ConfigurationManagerInterface
+{
+    /**
+     * @var array<string, mixed>
+     */
+    public $configuration = [];
+
+    public function setContentObject(ContentObjectRenderer $contentObject): void
+    {
+        // Intentionally left blank.
+    }
+
+    public function getContentObject(): ?ContentObjectRenderer
+    {
+        return null;
+    }
+
+    /**
+     * @inheritDoc
+     * @return array<string, mixed>
+     */
+    public function getConfiguration(string $configurationType, ?string $extensionName = null, ?string $pluginName = null): array
+    {
+        return $this->configuration;
+    }
+
+    /**
+     * @param array<string, mixed> $configuration
+     */
+    public function setConfiguration(array $configuration = []): void
+    {
+        $this->configuration = $configuration;
+    }
+
+    public function isFeatureEnabled(string $featureName): bool
+    {
+        return false;
+    }
+}

--- a/Tests/Unit/Fixtures/Classes/Renderer/Template/DummyTemplatePaths.php
+++ b/Tests/Unit/Fixtures/Classes/Renderer/Template/DummyTemplatePaths.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of the TYPO3 CMS extension "handlebars".
  *
- * Copyright (C) 2020 Elias Häußler <e.haeussler@familie-redlich.de>
+ * Copyright (C) 2021 Elias Häußler <e.haeussler@familie-redlich.de>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -21,32 +21,26 @@ declare(strict_types=1);
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-namespace Fr\Typo3Handlebars\Configuration;
+namespace Fr\Typo3Handlebars\Tests\Unit\Fixtures\Classes\Renderer\Template;
+
+use Fr\Typo3Handlebars\Renderer\Template\TemplatePaths;
 
 /**
- * Extension
+ * DummyTemplatePaths
  *
  * @author Elias Häußler <e.haeussler@familie-redlich.de>
  * @license GPL-2.0-or-later
- * @codeCoverageIgnore
+ * @internal
  */
-final class Extension
+final class DummyTemplatePaths extends TemplatePaths
 {
-    public const KEY = 'handlebars';
-    public const NAME = 'Handlebars';
-
     /**
-     * Register additional caches.
-     *
-     * FOR USE IN ext_localconf.php ONLY.
+     * @param string[] $templatePaths
+     * @return self
      */
-    public static function registerCaches(): void
+    public function setTemplatePaths(array $templatePaths): self
     {
-        if (!is_array($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['handlebars'] ?? null)) {
-            $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['handlebars'] = [];
-        }
-        if (!is_array($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['handlebars']['groups'])) {
-            $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['handlebars']['groups'] = ['pages'];
-        }
+        $this->templatePaths = $templatePaths;
+        return $this;
     }
 }

--- a/Tests/Unit/Renderer/Template/HandlebarsTemplateResolverTest.php
+++ b/Tests/Unit/Renderer/Template/HandlebarsTemplateResolverTest.php
@@ -59,7 +59,7 @@ class HandlebarsTemplateResolverTest extends UnitTestCase
         $this->expectExceptionCode(1613727984);
 
         /** @phpstan-ignore-next-line */
-        new HandlebarsTemplateResolver([null]);
+        new HandlebarsTemplateResolver($this->getTemplatePaths()->setTemplatePaths([null]));
     }
 
     /**
@@ -70,7 +70,7 @@ class HandlebarsTemplateResolverTest extends UnitTestCase
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionCode(1613728252);
 
-        new HandlebarsTemplateResolver(['EXT:foo/baz']);
+        new HandlebarsTemplateResolver($this->getTemplatePaths()->setTemplatePaths(['EXT:foo/baz']));
     }
 
     /**
@@ -82,7 +82,7 @@ class HandlebarsTemplateResolverTest extends UnitTestCase
         $this->expectExceptionCode(1613727952);
 
         /** @phpstan-ignore-next-line */
-        new HandlebarsTemplateResolver([$this->getTemplateRootPath()], [true]);
+        new HandlebarsTemplateResolver($this->getTemplatePaths(), [true]);
     }
 
     /**
@@ -93,7 +93,7 @@ class HandlebarsTemplateResolverTest extends UnitTestCase
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionCode(1613727713);
 
-        new HandlebarsTemplateResolver([$this->getTemplateRootPath()], ['.foo']);
+        new HandlebarsTemplateResolver($this->getTemplatePaths(), ['.foo']);
     }
 
     /**
@@ -104,7 +104,7 @@ class HandlebarsTemplateResolverTest extends UnitTestCase
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionCode(1613727593);
 
-        new HandlebarsTemplateResolver([$this->getTemplateRootPath()], ['foo?!']);
+        new HandlebarsTemplateResolver($this->getTemplatePaths(), ['foo?!']);
     }
 
     /**

--- a/Tests/Unit/Renderer/Template/TemplatePathsTest.php
+++ b/Tests/Unit/Renderer/Template/TemplatePathsTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "handlebars".
+ *
+ * Copyright (C) 2021 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace Fr\Typo3Handlebars\Tests\Unit\Renderer\Template;
+
+use Fr\Typo3Handlebars\Renderer\Template\TemplatePaths;
+use Fr\Typo3Handlebars\Tests\Unit\Fixtures\Classes\DummyConfigurationManager;
+use Fr\Typo3Handlebars\Tests\Unit\HandlebarsTemplateResolverTrait;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+/**
+ * TemplatePathsTest
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-2.0-or-later
+ */
+class TemplatePathsTest extends UnitTestCase
+{
+    use HandlebarsTemplateResolverTrait;
+
+    /**
+     * @var DummyConfigurationManager
+     */
+    protected $configurationManager;
+
+    /**
+     * @var TemplatePaths
+     */
+    protected $subject;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->configurationManager = new DummyConfigurationManager();
+        $this->subject = new TemplatePaths($this->configurationManager);
+        $this->subject->setContainer($this->getContainer());
+    }
+
+    /**
+     * @test
+     * @dataProvider getMergesConfigurationFromContainerWithTypoScriptConfigurationDataProvider
+     * @param array<string, array> $typoScriptConfiguration
+     * @param string[] $expected
+     */
+    public function getMergesConfigurationFromContainerWithTypoScriptConfiguration(
+        array $typoScriptConfiguration,
+        array $expected
+    ): void {
+        $this->configurationManager->setConfiguration($typoScriptConfiguration);
+
+        self::assertSame($expected, $this->subject->get());
+    }
+
+    /**
+     * @return \Generator<string, array>
+     */
+    public function getMergesConfigurationFromContainerWithTypoScriptConfigurationDataProvider(): \Generator
+    {
+        yield 'no TypoScript configuration' => [
+            [],
+            [
+                10 => $this->getTemplateRootPath(),
+            ],
+        ];
+        yield 'TypoScript configuration with identical keys' => [
+            [
+                'view' => [
+                    'templateRootPaths' => [
+                        '10' => 'foo',
+                    ],
+                ],
+            ],
+            [
+                10 => 'foo',
+            ],
+        ];
+        yield 'TypoScript configuration with additional keys' => [
+            [
+                'view' => [
+                    'templateRootPaths' => [
+                        '10' => 'foo',
+                        '20' => 'baz',
+                    ],
+                ],
+            ],
+            [
+                10 => 'foo',
+                20 => 'baz',
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
This PR introduces a new `TemplatePaths` class. It is used to merge configuration of template root paths and partial root paths from several configuration methods. Additionally, a new configuration method is introduced that allows definition of template root paths and partial root paths using TypoScript.

Example:

```typoscript
plugin.tx_handlebars {
  view {
    templateRootPaths {
      10 = EXT:my_extension/Resources/Private/Templates
    }
    partialRootPaths {
      10 = EXT:my_extension/Resources/Private/Partials
    }
  }
}
```

The new class `TemplatePaths` is now used within the `HandlebarsTemplateResolver` instead of passing an array of template root paths to it. This is a breaking change and should be considered when updating to the following new version of EXT:handlebars.