### PR TITLE
[FEATURE] Add support for installs in non-composer mode

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -87,6 +87,18 @@ jobs:
           extensions: intl, mbstring, json, zip, curl
           tools: composer:v2
 
+      # Build dependencies
+      - name: Build dependencies
+        env:
+          BUILD_PATH: Resources/Private/Libs/Build
+          LIB_PATH: Resources/Private/Libs
+        run: |
+          git reset --hard HEAD && git clean -dfx
+          composer global require clue/phar-composer
+          composer install -d $(pwd)/$BUILD_PATH
+          composer global exec phar-composer build $(pwd)/$BUILD_PATH $(pwd)/$LIB_PATH/vendors.phar
+          echo "\\Fr\\Typo3Handlebars\\Configuration\\Extension::loadVendorLibraries();" >> ext_localconf.php
+
       # Install tailor
       - name: Install tailor
         run: composer global require typo3/tailor --prefer-dist --no-progress --no-suggest

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 /.Build/
+/Resources/Private/Libs/Build/vendor
+/Resources/Private/Libs/vendors.phar
 /var/
 /.php_cs.cache
 /.phpunit.result.cache

--- a/Classes/Configuration/Extension.php
+++ b/Classes/Configuration/Extension.php
@@ -23,6 +23,9 @@ declare(strict_types=1);
 
 namespace Fr\Typo3Handlebars\Configuration;
 
+use TYPO3\CMS\Core\Core\Environment;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
 /**
  * Extension
  *
@@ -47,6 +50,24 @@ final class Extension
         }
         if (!is_array($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['handlebars']['groups'])) {
             $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['handlebars']['groups'] = ['pages'];
+        }
+    }
+
+    /**
+     * Load additional libraries provided by PHAR file (only to be used in non-Composer-mode).
+     *
+     * FOR USE IN ext_localconf.php AND NON-COMPOSER-MODE ONLY.
+     */
+    public static function loadVendorLibraries(): void
+    {
+        // Vendor libraries are already available in Composer mode
+        if (Environment::isComposerMode()) {
+            return;
+        }
+
+        $vendorPharFile = GeneralUtility::getFileAbsFileName('EXT:handlebars/Resources/Private/Libs/vendors.phar');
+        if (file_exists($vendorPharFile)) {
+            require_once 'phar://' . $vendorPharFile . '/vendor/autoload.php';
         }
     }
 }

--- a/Documentation/Installation/Index.rst
+++ b/Documentation/Installation/Index.rst
@@ -6,20 +6,12 @@
 Installation
 ============
 
-.. important::
-
-   **Composer installation required**
-
-   Installations from other sources than Composer (e.g. Extension Manager, TYPO3
-   Extension Repository) are currently not supported and might not work as expected.
-
 .. _requirements:
 
 Requirements
 ============
 
 * PHP 7.1 - 8.0
-* Composer
 * TYPO3 10.4 LTS - 11.x
 
 .. _steps:
@@ -32,6 +24,10 @@ Require the extension via Composer:
 .. code-block:: bash
 
    composer require cpsit/typo3-handlebars
+
+Or download it from
+`TYPO3 extension repository <https://extensions.typo3.org/extension/handlebars>`__
+(not recommended).
 
 .. _define-dependencies:
 
@@ -53,7 +49,7 @@ dependency in the appropriate :file:`ext_emconf.php` file:
    $EM_CONF[$_EXTKEY] = [
        'constraints' => [
            'depends' => [
-               'handlebars' => '0.5.0-0.5.99',
+               'handlebars' => '0.7.0-0.7.99',
            ],
        ],
    ];

--- a/Resources/Private/Libs/Build/composer.json
+++ b/Resources/Private/Libs/Build/composer.json
@@ -1,0 +1,20 @@
+{
+	"name": "cpsit/typo3-handlebars-libs",
+	"description": "Additional libraries to support non-composer mode of EXT:handlebars",
+	"license": "GPL-2.0-or-later",
+	"authors": [
+		{
+			"name": "Elias Häußler",
+			"email": "e.haeussler@familie-redlich.de",
+			"homepage": "https://www.familie-redlich.de",
+			"role": "Maintainer"
+		}
+	],
+	"require": {
+		"zordius/lightncandy": "^1.2"
+	},
+	"config": {
+		"lock": false
+	}
+
+}

--- a/packaging_exclude.php
+++ b/packaging_exclude.php
@@ -26,6 +26,7 @@ return [
         '.build',
         '.git',
         '.github',
+        'resources\\/private\\/libs\\/build',
         'tailor-version-upload',
         'tests',
     ],


### PR DESCRIPTION
This PR introduces the possibility to install EXT:handlebars in non-composer (= classic) installations. For this, all relevant vendor-libraries are included as phar file in the generated ZIP file during TER publish.