### PR TITLE
[FEATURE] Provide compatibility method for Extbase repositories

### DIFF
--- a/Documentation/Compatibility/ExtbaseRepositories.rst
+++ b/Documentation/Compatibility/ExtbaseRepositories.rst
@@ -1,0 +1,66 @@
+.. include:: ../Includes.txt
+
+.. _extbase-repositories:
+
+====================
+Extbase repositories
+====================
+
+.. versionadded:: 0.7.3
+
+   `Feature: #23 - Provide compatibility method for Extbase repositories <https://github.com/CPS-IT/handlebars/pull/23>`__
+
+.. warning::
+
+   **Use of the** `AbstractDataProcessor` **required**
+
+   This compatibility method is only applicable to `DataProcessors`
+   that extend the :php:`AbstractDataProcessor`, since it provides the
+   necessary method. It is not part of the :php:`DataProcessorInterface`.
+
+When Extbase repositories are used to fetch data via the `DataProvider`,
+it may be necessary to perform the necessary bootstrapping for Extbase
+repositories. This is the case whenever the rendering process is executed
+outside the Extbase context and fields such as `tt_content.pages` or
+`tt_content.recursive` are to be accessed in the repository to determine
+the storage PIDs.
+
+To execute the necessary bootstrapping or to reset the underlying
+:php:`ConfigurationManager` and to fill it with the current
+:php:`ContentObjectRenderer`, the method
+:php:`initializeConfigurationManager()` must be executed in the
+`DataProcessor`.
+
+.. _extbase-repositories-usage:
+
+Usage
+=====
+
+.. code-block:: diff
+
+    # Classes/DataProcessing/HeaderProcessor.php
+
+    namespace Vendor\Extension\DataProcessing;
+
+    use Fr\Typo3Handlebars\DataProcessing\AbstractDataProcessor;
+
+    class HeaderProcessor extends AbstractDataProcessor
+    {
+        protected function render(): string
+        {
+   +        $this->initializeConfigurationManager();
+            $data = $this->provider->get($this->cObj->data);
+            return $this->presenter->present($data);
+        }
+    }
+
+.. _extbase-repositories-sources:
+
+Sources
+=======
+
+.. seealso::
+
+   View the sources on GitHub:
+
+   -  `AbstractDataProcessor <https://github.com/CPS-IT/handlebars/blob/master/Classes/DataProcessing/AbstractDataProcessor.php>`__

--- a/Documentation/Compatibility/Index.rst
+++ b/Documentation/Compatibility/Index.rst
@@ -13,3 +13,4 @@ for compatibility with other TYPO3 components.
    :maxdepth: 1
 
    ExtbaseControllers
+   ExtbaseRepositories

--- a/Tests/Unit/Fixtures/Classes/DataProcessing/DummyProcessor.php
+++ b/Tests/Unit/Fixtures/Classes/DataProcessing/DummyProcessor.php
@@ -40,15 +40,25 @@ final class DummyProcessor extends AbstractDataProcessor
      */
     public $shouldThrowException = false;
 
+    /**
+     * @var bool
+     */
+    public $shouldInitializeConfigurationManager = false;
+
     protected function render(): string
     {
         if ($this->shouldThrowException) {
             throw new UnableToPresentException();
         }
+        if ($this->shouldInitializeConfigurationManager) {
+            $this->initializeConfigurationManager();
+        }
+
         $content = $this->content . $this->presenter->present($this->provider->get([]));
         if ($this->configuration !== []) {
             $content .= ' ' . json_encode($this->configuration);
         }
+
         return $content;
     }
 

--- a/Tests/Unit/Fixtures/Classes/DummyConfigurationManager.php
+++ b/Tests/Unit/Fixtures/Classes/DummyConfigurationManager.php
@@ -40,14 +40,19 @@ final class DummyConfigurationManager implements ConfigurationManagerInterface
      */
     public $configuration = [];
 
+    /**
+     * @var ContentObjectRenderer
+     */
+    private $cObj;
+
     public function setContentObject(ContentObjectRenderer $contentObject): void
     {
-        // Intentionally left blank.
+        $this->cObj = $contentObject;
     }
 
     public function getContentObject(): ?ContentObjectRenderer
     {
-        return null;
+        return $this->cObj;
     }
 
     /**


### PR DESCRIPTION
This PR provides a new compatibility method in `AbstractDataProcessor`. It can be used to reset the global `ConfigurationManager` that is responsible to e.g. resolve the storage PIDs defined in the current content element.

In order to use the new method, just call the `initializeConfigurationManager()` method in your data processor. **Note: This method is only available in case your data processor extends the `AbstractDataProcessor` class.**

```diff
 # Classes/DataProcessing/HeaderProcessor.php

 namespace Vendor\Extension\DataProcessing;

 use Fr\Typo3Handlebars\DataProcessing\AbstractDataProcessor;

 class HeaderProcessor extends AbstractDataProcessor
 {
     protected function render(): string
     {
+        $this->initializeConfigurationManager();
         $data = $this->provider->get($this->cObj->data);
         return $this->presenter->present($data);
     }
 }
```