### PR TITLE
[BUGFIX] Properly support helper functions in PHP 8 and higher

### DIFF
--- a/Classes/DependencyInjection/HandlebarsHelperPass.php
+++ b/Classes/DependencyInjection/HandlebarsHelperPass.php
@@ -27,6 +27,7 @@ use Fr\Typo3Handlebars\Renderer\HelperAwareInterface;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
 
 /**
  * HandlebarsHelperPass
@@ -71,16 +72,20 @@ final class HandlebarsHelperPass implements CompilerPassInterface
                 $this->validateTag($serviceId, $attributes);
                 $this->registerHelper(
                     $attributes['identifier'],
-                    sprintf('%s::%s', $serviceId, $attributes['method'])
+                    [new Reference($serviceId), $attributes['method']]
                 );
             }
         }
     }
 
-    private function registerHelper(string $name, string $function): void
+    /**
+     * @param string $name
+     * @param array{0: string|Reference, 1: string} $callable
+     */
+    private function registerHelper(string $name, array $callable): void
     {
         foreach ($this->rendererDefinitions as $rendererDefinition) {
-            $rendererDefinition->addMethodCall('registerHelper', [$name, $function]);
+            $rendererDefinition->addMethodCall('registerHelper', [$name, $callable]);
         }
     }
 

--- a/Classes/Exception/InvalidHelperException.php
+++ b/Classes/Exception/InvalidHelperException.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "handlebars".
+ *
+ * Copyright (C) 2021 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace Fr\Typo3Handlebars\Exception;
+
+/**
+ * InvalidHelperException
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-2.0-or-later
+ */
+final class InvalidHelperException extends \Exception
+{
+    public static function forFunction(string $helperFunction): self
+    {
+        return new self(
+            sprintf('The helper function "%s" is invalid.', $helperFunction),
+            1637339290
+        );
+    }
+
+    /**
+     * @param mixed $helperFunction
+     * @return self
+     */
+    public static function forUnsupportedType($helperFunction): self
+    {
+        return new self(
+            sprintf('Only callables, strings and arrays can be defined as helpers, "%s" given.', gettype($helperFunction)),
+            1637339694
+        );
+    }
+}

--- a/Classes/Traits/HandlebarsHelperTrait.php
+++ b/Classes/Traits/HandlebarsHelperTrait.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace Fr\Typo3Handlebars\Traits;
 
+use Fr\Typo3Handlebars\Exception\InvalidHelperException;
 use Psr\Log\LoggerInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
@@ -45,16 +46,15 @@ trait HandlebarsHelperTrait
      */
     public function registerHelper(string $name, $function): void
     {
-        if ($this->isValidHelper($function)) {
+        try {
             $this->helpers[$name] = $this->resolveHelperFunction($function);
-            return;
-        }
-
-        if ($this->logger instanceof LoggerInterface) {
-            $this->logger->critical(
-                'Error while registering Handlebars helper "' . $name . '".',
-                ['name' => $name, 'function' => $function]
-            );
+        } catch (InvalidHelperException | \ReflectionException $exception) {
+            if ($this->logger instanceof LoggerInterface) {
+                $this->logger->critical(
+                    'Error while registering Handlebars helper "' . $name . '".',
+                    ['name' => $name, 'function' => $function, 'exception' => $exception]
+                );
+            }
         }
     }
 
@@ -69,19 +69,77 @@ trait HandlebarsHelperTrait
     /**
      * @param mixed $function
      * @return callable
+     * @throws InvalidHelperException
+     * @throws \ReflectionException
      */
     protected function resolveHelperFunction($function): callable
     {
-        if (!is_string($function) || strpos($function, '::') === false) {
+        // Try to resolve the Helper function in this order:
+        //
+        // 1. callable
+        // 2. invokable class
+        // ├─ a. as string (class-name)
+        // └─ b. as object
+        // 3. class method
+        // ├─ a. as string => class-name::method-name
+        // ├─ b. as array => [class-name, method-name]
+        // └─ c. as initialized array => [object, method-name]
+
+        $className = null;
+        $methodName = null;
+
+        if (is_string($function) && !str_contains($function, '::')) {
+            // 1. callable
+            if (is_callable($function)) {
+                return $function;
+            }
+
+            // 2a. invokable class as string
+            if (class_exists($function) && is_callable($callable = GeneralUtility::makeInstance($function))) {
+                return $callable;
+            }
+        }
+
+        // 2b. invokable class as object
+        if (is_object($function) && is_callable($function)) {
             return $function;
         }
 
-        // Instantiate class and use combination of object and method name as callable Helper function
-        /** @var class-string $className */
-        [$className, $methodName] = explode('::', $function);
-        $instance = GeneralUtility::makeInstance($className);
+        // 3a. class method as string
+        if (is_string($function) && str_contains($function, '::')) {
+            [$className, $methodName] = explode('::', $function, 2);
+        }
 
-        return [$instance, $methodName];
+        // 3b. class method as array
+        // 3c. class method as initialized array
+        if (is_array($function) && 2 === count($function)) {
+            [$className, $methodName] = $function;
+        }
+
+        // Early return if either class name or method name cannot be resolved
+        if (null === $className || null === $methodName) {
+            throw InvalidHelperException::forUnsupportedType($function);
+        }
+
+        // Early return if method is not public
+        $reflectionClass = new \ReflectionClass($className);
+        $reflectionMethod = $reflectionClass->getMethod($methodName);
+        if (!$reflectionMethod->isPublic()) {
+            throw InvalidHelperException::forFunction($className . '::' . $methodName);
+        }
+
+        // Check if method can be called statically
+        if ($reflectionMethod->isStatic()) {
+            return [$className, $methodName];
+        }
+
+        // Instantiate class if not done yet
+        /** @var class-string $className */
+        if (is_string($className)) {
+            $className = GeneralUtility::makeInstance($className);
+        }
+
+        return [$className, $methodName];
     }
 
     /**
@@ -90,6 +148,10 @@ trait HandlebarsHelperTrait
      */
     protected function isValidHelper($helperFunction): bool
     {
-        return is_callable($helperFunction);
+        try {
+            return (bool)$this->resolveHelperFunction($helperFunction);
+        } catch (InvalidHelperException | \ReflectionException $e) {
+            return false;
+        }
     }
 }

--- a/Classes/Traits/HandlebarsHelperTrait.php
+++ b/Classes/Traits/HandlebarsHelperTrait.php
@@ -145,9 +145,21 @@ trait HandlebarsHelperTrait
     /**
      * @param mixed $helperFunction
      * @return bool
+     * @codeCoverageIgnore
+     * @deprecated use resolveHelperFunction() instead and check for thrown exceptions
      */
     protected function isValidHelper($helperFunction): bool
     {
+        trigger_error(
+            sprintf(
+                'The method "%s" is deprecated and will be removed with 0.9.0. ' .
+                'Use "%s::resolveHelperFunction()" instead and check for thrown exceptions.',
+                __METHOD__,
+                __TRAIT__
+            ),
+            E_USER_DEPRECATED
+        );
+
         try {
             return (bool)$this->resolveHelperFunction($helperFunction);
         } catch (InvalidHelperException | \ReflectionException $e) {

--- a/Tests/Unit/Exception/InvalidHelperExceptionTest.php
+++ b/Tests/Unit/Exception/InvalidHelperExceptionTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "handlebars".
+ *
+ * Copyright (C) 2021 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace Fr\Typo3Handlebars\Tests\Unit\Exception;
+
+use Fr\Typo3Handlebars\Exception\InvalidHelperException;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+/**
+ * InvalidHelperExceptionTest
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-2.0-or-later
+ */
+class InvalidHelperExceptionTest extends UnitTestCase
+{
+    /**
+     * @test
+     */
+    public function forFunctionReturnsExceptionForGivenFunction(): void
+    {
+        $actual = InvalidHelperException::forFunction('foo');
+
+        self::assertInstanceOf(InvalidHelperException::class, $actual);
+        self::assertSame('The helper function "foo" is invalid.', $actual->getMessage());
+        self::assertSame(1637339290, $actual->getCode());
+    }
+
+    /**
+     * @test
+     */
+    public function forUnsupportedType(): void
+    {
+        $actual = InvalidHelperException::forUnsupportedType(null);
+
+        self::assertInstanceOf(InvalidHelperException::class, $actual);
+        self::assertSame('Only callables, strings and arrays can be defined as helpers, "NULL" given.', $actual->getMessage());
+        self::assertSame(1637339694, $actual->getCode());
+    }
+}

--- a/Tests/Unit/Fixtures/Classes/Renderer/Helper/DummyHelper.php
+++ b/Tests/Unit/Fixtures/Classes/Renderer/Helper/DummyHelper.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "handlebars".
+ *
+ * Copyright (C) 2021 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace Fr\Typo3Handlebars\Tests\Unit\Fixtures\Classes\Renderer\Helper;
+
+use Fr\Typo3Handlebars\Renderer\Helper\HelperInterface;
+
+/**
+ * DummyHelper
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-2.0-or-later
+ * @internal
+ */
+final class DummyHelper implements HelperInterface
+{
+    public function __invoke(): string
+    {
+        return 'foo';
+    }
+
+    public static function staticExecute(): string
+    {
+        return 'foo';
+    }
+
+    public function execute(): string
+    {
+        return 'foo';
+    }
+
+    /* @phpstan-ignore-next-line */
+    private function executeInternal(): string
+    {
+        return 'foo';
+    }
+}

--- a/Tests/Unit/Traits/HandlebarsHelperTraitTest.php
+++ b/Tests/Unit/Traits/HandlebarsHelperTraitTest.php
@@ -23,8 +23,8 @@ declare(strict_types=1);
 
 namespace Fr\Typo3Handlebars\Tests\Unit\Traits;
 
+use Fr\Typo3Handlebars\Tests\Unit\Fixtures\Classes\Renderer\Helper\DummyHelper;
 use Fr\Typo3Handlebars\Tests\Unit\Fixtures\Classes\Traits\DummyHandlebarsHelperTraitClass;
-use Fr\Typo3Handlebars\Traits\HandlebarsHelperTrait;
 use Psr\Log\Test\TestLogger;
 use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
 
@@ -114,8 +114,9 @@ class HandlebarsHelperTraitTest extends UnitTestCase
     {
         yield 'null value' => [null];
         yield 'non-callable function as string' => ['foo_baz'];
-        yield 'non-callable class method' => [HandlebarsHelperTrait::class . '::isValidHelper'];
-        yield 'non-callable class method in array syntax' => [[$this->subject, 'isValidHelper']];
+        yield 'non-callable class method' => [DummyHelper::class . '::foo'];
+        yield 'non-callable class method in array syntax' => [[new DummyHelper(), 'foo']];
+        yield 'non-callable private class method' => [DummyHelper::class . '::executeInternal'];
     }
 
     /**
@@ -127,13 +128,33 @@ class HandlebarsHelperTraitTest extends UnitTestCase
             'trim',
             'trim',
         ];
-        yield 'callable class method' => [
-            self::class . '::assertSame',
-            [new self(), 'assertSame'],
+        yield 'invokable class as string' => [
+            DummyHelper::class,
+            new DummyHelper(),
         ];
-        yield 'callable class method in array syntax' => [
-            [$this, 'assertSame'],
-            [$this, 'assertSame'],
+        yield 'invokable class as object' => [
+            new DummyHelper(),
+            new DummyHelper(),
+        ];
+        yield 'callable static class method' => [
+            DummyHelper::class . '::staticExecute',
+            [DummyHelper::class, 'staticExecute'],
+        ];
+        yield 'callable non-static class method' => [
+            DummyHelper::class . '::execute',
+            [new DummyHelper(), 'execute'],
+        ];
+        yield 'callable static class method in array syntax' => [
+            [DummyHelper::class, 'staticExecute'],
+            [DummyHelper::class, 'staticExecute'],
+        ];
+        yield 'callable non-static class method in array syntax' => [
+            [DummyHelper::class, 'execute'],
+            [new DummyHelper(), 'execute'],
+        ];
+        yield 'callable non-static class method in initialized array syntax' => [
+            [new DummyHelper(), 'execute'],
+            [new DummyHelper(), 'execute'],
         ];
     }
 }


### PR DESCRIPTION
This PR adds full support for Handlebars helper functions in PHP 8 and higher.

## Problem

Handlebars helper are normally registered using `Services.yaml` file or explicitly in the form `<class-name>::<method-name>`. In order to test whether the passed function for registering the helper is valid, a simple `is_callable` check was performed. PHP versions lower than 8.0 allowed to pass both static and non-static class methods in this form.

However, PHP 8.0 is more strict in various ways and no longer evaluates to `true` when passing non-static methods in the form `<class-name>::<method-name>` to `is_callable`. This leads to the fact that **all** helpers won't get registered when passed in with mentioned registration methods.

## Solution

The validity check for passed Handlebars helpers is now defined in a way that various spellings are possible along all officially supported PHP versions (7.1.0 - 8.0.99).

Helper functions are now evaluated the following way:

| # | Type | Example |
| --- | --- | --- |
| 1. | callable | `'trim'` |
| 2. | invokable class |
| _2a._ | _as string (class-name)_ | `'Vendor\Extension\Renderer\Helper\MyHelper'` |
| _2b._ | _as object_ | `new Vendor\Extension\Renderer\Helper\MyHelper()` |
| 3. | class method |
| _3a._ | _as string_ | `'Vendor\Extension\Renderer\Helper\MyHelper::execute'` |
| _3b._ | _as array_ | `['Vendor\Extension\Renderer\Helper\MyHelper', 'execute']` |
| _3c._ | _as initialized array_ | `[new Vendor\Extension\Renderer\Helper\MyHelper(), 'execute']` |

## Additional changes

### Deprecated

* The method `Fr\Typo3Handlebars\Traits\HandlebarsHelperTrait::isValidHelper()` has been deprecated
  - Use `Fr\Typo3Handlebars\Traits\HandlebarsHelperTrait::resolveHelperFunction()` instead and check for thrown exceptions
  - Will be removed with version 0.9.0
 
### Updated

* Helper classes configured for registration at Handlebars renderers are now stored as reference in the service container to avoid superfluous `GeneralUtility::makeInstance`