### PR TITLE
[FEATURE] Write compile result in `typo3temp` instead of `sys_get_temp_dir()`

### DIFF
--- a/Classes/Renderer/HandlebarsRenderer.php
+++ b/Classes/Renderer/HandlebarsRenderer.php
@@ -39,6 +39,7 @@ use LightnCandy\Runtime;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 
 /**
@@ -145,13 +146,7 @@ class HandlebarsRenderer implements RendererInterface, HelperAwareInterface, Log
 
         // Compile template
         $compileResult = $this->compile($template);
-        /** @var \Closure|false $renderer */
-        $renderer = LightnCandy::prepare($compileResult);
-
-        // Handle closure preparation failures
-        if (!is_callable($renderer)) {
-            throw new TemplateCompilationException('Cannot prepare compiled render function.', 1614705397);
-        }
+        $renderer = $this->prepareCompileResult($compileResult);
 
         // Dispatch before rendering event
         $beforeRenderingEvent = new BeforeRenderingEvent($fullTemplatePath, $mergedData, $this);
@@ -233,6 +228,32 @@ class HandlebarsRenderer implements RendererInterface, HelperAwareInterface, Log
             $flags |= LightnCandy::FLAG_RENDER_DEBUG;
         }
         return $flags;
+    }
+
+    protected function prepareCompileResult(string $compileResult): callable
+    {
+        // Touch temporary file
+        $path = GeneralUtility::tempnam('hbs_');
+
+        // Write file and validate write result
+        /** @var string|null $writeResult */
+        $writeResult = GeneralUtility::writeFileToTypo3tempDir($path, '<?php ' . $compileResult);
+        if (null !== $writeResult) {
+            throw new TemplateCompilationException(sprintf('Cannot prepare compiled render function: %s', $writeResult), 1614705397);
+        }
+
+        // Build callable
+        $callable = include $path;
+
+        // Remove temporary file
+        GeneralUtility::unlink_tempfile($path);
+
+        // Validate callable
+        if (!is_callable($callable)) {
+            throw new TemplateCompilationException('Got invalid compile result from compiler.', 1639405571);
+        }
+
+        return $callable;
     }
 
     /**

--- a/Tests/Unit/Renderer/HandlebarsRendererTest.php
+++ b/Tests/Unit/Renderer/HandlebarsRendererTest.php
@@ -157,7 +157,7 @@ class HandlebarsRendererTest extends UnitTestCase
             file_get_contents(
                 $this->getTemplateResolver()->resolveTemplatePath('DummyTemplate')
             ) ?: '',
-            'return function() { return \'foo\'; }'
+            'return function() { return \'foo\'; };'
         );
         $this->assertCacheIsNotEmptyForTemplate('DummyTemplate.hbs');
 
@@ -228,7 +228,8 @@ class HandlebarsRendererTest extends UnitTestCase
             /** @var TemplateCompilationException $exception */
             $exception = $logRecord['context']['exception'];
             static::assertInstanceOf(TemplateCompilationException::class, $exception);
-            static::assertSame(1614705397, $exception->getCode());
+            static::assertSame('Got invalid compile result from compiler.', $exception->getMessage());
+            static::assertSame(1639405571, $exception->getCode());
             return true;
         }));
     }


### PR DESCRIPTION
This PR changes the way how compile results are prepared for rendering.

Prior to this change, the compile results were written to `sys_get_temp_dir()` which is a bit spooky (since application-relevant files are no longer stored inside the application and depend on successful permission handling of those directories). Since TYPO3 already serves a temporary directory for such cases (`typo3temp/var/transient`), this one is now used to store compile results.

This drops the usage of the deprecated `LightnCandy\LightnCandy::prepare()` as well.