### PR TITLE
[BUGFIX] Follow-up: Add setter for $cObj in SimpleProcessor as well

### DIFF
--- a/Classes/DataProcessing/SimpleProcessor.php
+++ b/Classes/DataProcessing/SimpleProcessor.php
@@ -86,4 +86,10 @@ class SimpleProcessor implements DataProcessorInterface, LoggerAwareInterface
         }
         return trim($configuration['userFunc.']['templatePath']);
     }
+
+    public function setContentObjectRenderer(ContentObjectRenderer $cObj): self
+    {
+        $this->cObj = $cObj;
+        return $this;
+    }
 }

--- a/Tests/Unit/DataProcessing/SimpleProcessorTest.php
+++ b/Tests/Unit/DataProcessing/SimpleProcessorTest.php
@@ -128,6 +128,18 @@ class SimpleProcessorTest extends UnitTestCase
     }
 
     /**
+     * @test
+     */
+    public function setContentObjectRendererAppliesContentObjectRenderer(): void
+    {
+        $contentObjectRenderer = new ContentObjectRenderer();
+
+        $this->subject->setContentObjectRenderer($contentObjectRenderer);
+
+        self::assertSame($contentObjectRenderer, $this->subject->cObj);
+    }
+
+    /**
      * @return \Generator<string, array<mixed>>
      */
     public function processThrowsExceptionIfTemplatePathIsNotConfiguredDataProvider(): \Generator


### PR DESCRIPTION
Since TYPO3 11.4 and https://forge.typo3.org/issues/94956 the use of the public property `$cObj` in data processors is deprecated. As a replacement, a public setter `setContentObjectRenderer` should be used.

This PR adds this setter in `SimpleProcessor` but keeps the public property as-is to assure compatibility with TYPO3 < 11.4. This is a follow-up to #14.