### PR TITLE
[TASK] Enable additional PHP-CS-Fixer rules

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 $config = \TYPO3\CodingStandards\CsFixerConfig::create()
     ->addRules([
         'native_function_invocation' => true,
+        'no_superfluous_phpdoc_tags' => ['allow_mixed' => true],
     ]);
 
 $finder = $config->getFinder()

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -2,7 +2,11 @@
 
 declare(strict_types=1);
 
-$config = \TYPO3\CodingStandards\CsFixerConfig::create();
+$config = \TYPO3\CodingStandards\CsFixerConfig::create()
+    ->addRules([
+        'native_function_invocation' => true,
+    ]);
+
 $finder = $config->getFinder()
     ->in(__DIR__)
     ->ignoreVCSIgnored(true);

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -1,5 +1,10 @@
 <?php
 
+declare(strict_types=1);
+
 $config = \TYPO3\CodingStandards\CsFixerConfig::create();
-$config->getFinder()->in(__DIR__);
+$finder = $config->getFinder()
+    ->in(__DIR__)
+    ->ignoreVCSIgnored(true);
+
 return $config;

--- a/Classes/Cache/CacheInterface.php
+++ b/Classes/Cache/CacheInterface.php
@@ -31,15 +31,7 @@ namespace Fr\Typo3Handlebars\Cache;
  */
 interface CacheInterface
 {
-    /**
-     * @param string $template
-     * @return string|null
-     */
     public function get(string $template): ?string;
 
-    /**
-     * @param string $template
-     * @param string $compileResult
-     */
     public function set(string $template, string $compileResult): void;
 }

--- a/Classes/Compatibility/View/ExtbaseViewAdapter.php
+++ b/Classes/Compatibility/View/ExtbaseViewAdapter.php
@@ -68,7 +68,6 @@ class ExtbaseViewAdapter implements ViewInterface
 
     /**
      * @param array<string, mixed> $values
-     * @return self
      */
     public function assignMultiple(array $values): self
     {

--- a/Classes/Compatibility/View/HandlebarsViewResolver.php
+++ b/Classes/Compatibility/View/HandlebarsViewResolver.php
@@ -84,7 +84,6 @@ class HandlebarsViewResolver extends GenericViewResolver
 
     /**
      * @param array<string, array<string, DataProcessorInterface>> $processorMap
-     * @return self
      */
     public function setProcessorMap(array $processorMap): self
     {

--- a/Classes/Compatibility/View/HandlebarsViewResolver.php
+++ b/Classes/Compatibility/View/HandlebarsViewResolver.php
@@ -64,7 +64,7 @@ class HandlebarsViewResolver extends GenericViewResolver
 
     protected function getProcessor(string $controllerClassName, string $actionName): ?DataProcessorInterface
     {
-        if (!array_key_exists($controllerClassName, $this->processorMap)) {
+        if (!\array_key_exists($controllerClassName, $this->processorMap)) {
             return null;
         }
 

--- a/Classes/Configuration/Extension.php
+++ b/Classes/Configuration/Extension.php
@@ -45,10 +45,10 @@ final class Extension
      */
     public static function registerCaches(): void
     {
-        if (!is_array($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['handlebars'] ?? null)) {
+        if (!\is_array($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['handlebars'] ?? null)) {
             $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['handlebars'] = [];
         }
-        if (!is_array($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['handlebars']['groups'] ?? null)) {
+        if (!\is_array($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['handlebars']['groups'] ?? null)) {
             $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['handlebars']['groups'] = ['pages'];
         }
     }

--- a/Classes/Data/DataProviderInterface.php
+++ b/Classes/Data/DataProviderInterface.php
@@ -35,7 +35,6 @@ interface DataProviderInterface
 {
     /**
      * @param array<string, mixed> $data
-     * @return ProviderResponseInterface
      */
     public function get(array $data): ProviderResponseInterface;
 }

--- a/Classes/Data/Response/SimpleProviderResponse.php
+++ b/Classes/Data/Response/SimpleProviderResponse.php
@@ -48,7 +48,7 @@ class SimpleProviderResponse implements ProviderResponseInterface, \ArrayAccess
 
     public function offsetExists($offset): bool
     {
-        return array_key_exists($offset, $this->data);
+        return \array_key_exists($offset, $this->data);
     }
 
     public function offsetGet($offset)

--- a/Classes/DataProcessing/AbstractDataProcessor.php
+++ b/Classes/DataProcessing/AbstractDataProcessor.php
@@ -97,8 +97,6 @@ abstract class AbstractDataProcessor implements DataProcessorInterface, LoggerAw
 
     /**
      * @required
-     * @param PresenterInterface $presenter
-     * @return DataProcessorInterface
      */
     public function setPresenter(PresenterInterface $presenter): DataProcessorInterface
     {
@@ -108,8 +106,6 @@ abstract class AbstractDataProcessor implements DataProcessorInterface, LoggerAw
 
     /**
      * @required
-     * @param DataProviderInterface $provider
-     * @return DataProcessorInterface
      */
     public function setProvider(DataProviderInterface $provider): DataProcessorInterface
     {

--- a/Classes/DataProcessing/DataProcessorInterface.php
+++ b/Classes/DataProcessing/DataProcessorInterface.php
@@ -32,9 +32,7 @@ namespace Fr\Typo3Handlebars\DataProcessing;
 interface DataProcessorInterface
 {
     /**
-     * @param string $content
      * @param array<string|int, mixed> $configuration
-     * @return string
      */
     public function process(string $content, array $configuration): string;
 }

--- a/Classes/DataProcessing/SimpleProcessor.php
+++ b/Classes/DataProcessing/SimpleProcessor.php
@@ -69,7 +69,6 @@ class SimpleProcessor implements DataProcessorInterface, LoggerAwareInterface
 
     /**
      * @param array<string|int, mixed> $configuration
-     * @return string
      * @throws InvalidTemplateFileException
      */
     protected function getTemplatePath(array $configuration): string

--- a/Classes/DataProcessing/SimpleProcessor.php
+++ b/Classes/DataProcessing/SimpleProcessor.php
@@ -75,8 +75,8 @@ class SimpleProcessor implements DataProcessorInterface, LoggerAwareInterface
     protected function getTemplatePath(array $configuration): string
     {
         if (
-            !array_key_exists('templatePath', $configuration['userFunc.'] ?? []) ||
-            !is_string($configuration['userFunc.']['templatePath']) ||
+            !\array_key_exists('templatePath', $configuration['userFunc.'] ?? []) ||
+            !\is_string($configuration['userFunc.']['templatePath']) ||
             trim($configuration['userFunc.']['templatePath']) === ''
         ) {
             throw new InvalidTemplateFileException(

--- a/Classes/DependencyInjection/Compatibility/CompatibilityLayerInterface.php
+++ b/Classes/DependencyInjection/Compatibility/CompatibilityLayerInterface.php
@@ -33,9 +33,7 @@ namespace Fr\Typo3Handlebars\DependencyInjection\Compatibility;
 interface CompatibilityLayerInterface
 {
     /**
-     * @param string $processorServiceId
      * @param array<string, mixed> $configuration
-     * @return bool
      */
     public function provide(string $processorServiceId, array $configuration): bool;
 }

--- a/Classes/DependencyInjection/Compatibility/ExtbaseControllerCompatibilityLayer.php
+++ b/Classes/DependencyInjection/Compatibility/ExtbaseControllerCompatibilityLayer.php
@@ -132,15 +132,15 @@ final class ExtbaseControllerCompatibilityLayer implements CompatibilityLayerInt
                 1632814520
             );
         }
-        if (!in_array(ActionController::class, class_parents($this->container->getDefinition($configuration['controller'])->getClass()) ?: [])) {
+        if (!\in_array(ActionController::class, class_parents($this->container->getDefinition($configuration['controller'])->getClass()) ?: [])) {
             throw new \InvalidArgumentException(
                 sprintf('Only extbase controllers extending from "%s" are supported, found in: %s', ActionController::class, $configuration['controller']),
                 1632814592
             );
         }
-        if (isset($configuration['actions']) && !is_string($configuration['actions']) && null !== $configuration['actions']) {
+        if (isset($configuration['actions']) && !\is_string($configuration['actions']) && null !== $configuration['actions']) {
             throw new \InvalidArgumentException(
-                sprintf('Actions for extbase controllers must be configured as comma-separated list, %s given.', gettype($configuration['actions'])),
+                sprintf('Actions for extbase controllers must be configured as comma-separated list, %s given.', \gettype($configuration['actions'])),
                 1632814413
             );
         }

--- a/Classes/DependencyInjection/Compatibility/ProcessorCompatibility.php
+++ b/Classes/DependencyInjection/Compatibility/ProcessorCompatibility.php
@@ -51,9 +51,7 @@ final class ProcessorCompatibility
     private $container;
 
     /**
-     * @param string $serviceId
      * @param array<string, mixed> $tagAttributes
-     * @param ContainerBuilder $container
      */
     public function __construct(string $serviceId, array $tagAttributes, ContainerBuilder $container)
     {
@@ -75,8 +73,6 @@ final class ProcessorCompatibility
     }
 
     /**
-     * @param string $type
-     * @return CompatibilityLayerInterface
      * @throws UnsupportedTypeException
      */
     private function buildLayerForType(string $type): CompatibilityLayerInterface

--- a/Classes/DependencyInjection/Extension/Configuration.php
+++ b/Classes/DependencyInjection/Extension/Configuration.php
@@ -87,9 +87,9 @@ final class Configuration implements ConfigurationInterface
             if ($transitions === null) {
                 return [];
             }
-            if (!is_array($transitions)) {
+            if (!\is_array($transitions)) {
                 throw new \InvalidArgumentException(
-                    sprintf('Illegal value for root path configuration. Only numeric arrays are allowed, got "%s" instead.', gettype($transitions)),
+                    sprintf('Illegal value for root path configuration. Only numeric arrays are allowed, got "%s" instead.', \gettype($transitions)),
                     1615835938
                 );
             }
@@ -109,6 +109,6 @@ final class Configuration implements ConfigurationInterface
      */
     private function containsNonNumericIndexes(array $array): bool
     {
-        return count(array_filter(array_keys($array), 'is_string')) !== 0;
+        return \count(array_filter(array_keys($array), 'is_string')) !== 0;
     }
 }

--- a/Classes/DependencyInjection/Extension/Configuration.php
+++ b/Classes/DependencyInjection/Extension/Configuration.php
@@ -105,7 +105,6 @@ final class Configuration implements ConfigurationInterface
 
     /**
      * @param array<mixed, mixed> $array
-     * @return bool
      */
     private function containsNonNumericIndexes(array $array): bool
     {

--- a/Classes/DependencyInjection/Extension/HandlebarsExtension.php
+++ b/Classes/DependencyInjection/Extension/HandlebarsExtension.php
@@ -57,7 +57,6 @@ final class HandlebarsExtension extends Extension
 
     /**
      * @param array<mixed, mixed>[] $configs
-     * @param ContainerBuilder $container
      */
     public function load(array $configs, ContainerBuilder $container): void
     {
@@ -84,7 +83,6 @@ final class HandlebarsExtension extends Extension
 
     /**
      * @param array<mixed, mixed>[] $configs
-     * @param string $configKey
      * @return array<mixed, mixed>
      */
     private function mergeConfigs(array $configs, string $configKey): array

--- a/Classes/DependencyInjection/HandlebarsHelperPass.php
+++ b/Classes/DependencyInjection/HandlebarsHelperPass.php
@@ -79,7 +79,6 @@ final class HandlebarsHelperPass implements CompilerPassInterface
     }
 
     /**
-     * @param string $name
      * @param array{0: string|Reference, 1: string} $callable
      */
     private function registerHelper(string $name, array $callable): void
@@ -104,7 +103,6 @@ final class HandlebarsHelperPass implements CompilerPassInterface
     }
 
     /**
-     * @param string $serviceId
      * @param array<string, string> $tagAttributes
      */
     private function validateTag(string $serviceId, array $tagAttributes): void

--- a/Classes/DependencyInjection/HandlebarsHelperPass.php
+++ b/Classes/DependencyInjection/HandlebarsHelperPass.php
@@ -97,7 +97,7 @@ final class HandlebarsHelperPass implements CompilerPassInterface
             $rendererDefinition = $container->findDefinition($serviceId);
             $rendererClass = $rendererDefinition->getClass();
 
-            if (null !== $rendererClass && in_array(HelperAwareInterface::class, class_implements($rendererClass) ?: [])) {
+            if (null !== $rendererClass && \in_array(HelperAwareInterface::class, class_implements($rendererClass) ?: [])) {
                 $this->rendererDefinitions[] = $rendererDefinition;
             }
         }
@@ -109,13 +109,13 @@ final class HandlebarsHelperPass implements CompilerPassInterface
      */
     private function validateTag(string $serviceId, array $tagAttributes): void
     {
-        if (!array_key_exists('identifier', $tagAttributes) || '' === (string)$tagAttributes['identifier']) {
+        if (!\array_key_exists('identifier', $tagAttributes) || '' === (string)$tagAttributes['identifier']) {
             throw new \InvalidArgumentException(
                 sprintf('Service tag "%s" requires an identifier attribute to be defined, missing in: %s', $this->helperTagName, $serviceId),
                 1606236820
             );
         }
-        if (!array_key_exists('method', $tagAttributes) || '' === (string)$tagAttributes['method']) {
+        if (!\array_key_exists('method', $tagAttributes) || '' === (string)$tagAttributes['method']) {
             throw new \InvalidArgumentException(
                 sprintf('Service tag "%s" requires an method attribute to be defined, missing in: %s', $this->helperTagName, $serviceId),
                 1606245140

--- a/Classes/Event/BeforeRenderingEvent.php
+++ b/Classes/Event/BeforeRenderingEvent.php
@@ -49,9 +49,7 @@ class BeforeRenderingEvent
     private $renderer;
 
     /**
-     * @param string $templatePath
      * @param array<mixed, mixed> $data
-     * @param HandlebarsRenderer $renderer
      */
     public function __construct(string $templatePath, array $data, HandlebarsRenderer $renderer)
     {
@@ -75,7 +73,6 @@ class BeforeRenderingEvent
 
     /**
      * @param array<mixed, mixed> $data
-     * @return self
      */
     public function setData(array $data): self
     {

--- a/Classes/Exception/InvalidClassException.php
+++ b/Classes/Exception/InvalidClassException.php
@@ -33,7 +33,6 @@ final class InvalidClassException extends \RuntimeException
 {
     /**
      * @param class-string $className
-     * @return self
      */
     public static function create(string $className): self
     {

--- a/Classes/Exception/InvalidHelperException.php
+++ b/Classes/Exception/InvalidHelperException.php
@@ -46,7 +46,7 @@ final class InvalidHelperException extends \Exception
     public static function forUnsupportedType($helperFunction): self
     {
         return new self(
-            sprintf('Only callables, strings and arrays can be defined as helpers, "%s" given.', gettype($helperFunction)),
+            sprintf('Only callables, strings and arrays can be defined as helpers, "%s" given.', \gettype($helperFunction)),
             1637339694
         );
     }
@@ -60,7 +60,7 @@ final class InvalidHelperException extends \Exception
         [$className, $methodName] = $callable;
 
         return new self(
-            sprintf('The helper function with callable [%s, %s] is not valid.', gettype($className), gettype($methodName)),
+            sprintf('The helper function with callable [%s, %s] is not valid.', \gettype($className), \gettype($methodName)),
             1638180355
         );
     }

--- a/Classes/Exception/InvalidHelperException.php
+++ b/Classes/Exception/InvalidHelperException.php
@@ -41,7 +41,6 @@ final class InvalidHelperException extends \Exception
 
     /**
      * @param mixed $helperFunction
-     * @return self
      */
     public static function forUnsupportedType($helperFunction): self
     {
@@ -53,7 +52,6 @@ final class InvalidHelperException extends \Exception
 
     /**
      * @param array{class-string|object, string} $callable
-     * @return self
      */
     public static function forInvalidCallable(array $callable): self
     {

--- a/Classes/Presenter/PresenterInterface.php
+++ b/Classes/Presenter/PresenterInterface.php
@@ -33,9 +33,5 @@ use Fr\Typo3Handlebars\Data\Response\ProviderResponseInterface;
  */
 interface PresenterInterface
 {
-    /**
-     * @param ProviderResponseInterface $data
-     * @return string
-     */
     public function present(ProviderResponseInterface $data): string;
 }

--- a/Classes/Renderer/HandlebarsRenderer.php
+++ b/Classes/Renderer/HandlebarsRenderer.php
@@ -84,10 +84,6 @@ class HandlebarsRenderer implements RendererInterface, HelperAwareInterface, Log
     protected $debugMode;
 
     /**
-     * @param CacheInterface $cache
-     * @param EventDispatcherInterface $eventDispatcher
-     * @param TemplateResolverInterface $templateResolver
-     * @param TemplateResolverInterface|null $partialResolver
      * @param array<mixed, mixed> $defaultData
      */
     public function __construct(
@@ -119,9 +115,7 @@ class HandlebarsRenderer implements RendererInterface, HelperAwareInterface, Log
     }
 
     /**
-     * @param string $templatePath
      * @param array<mixed, mixed> $data
-     * @return string
      * @throws InvalidTemplateFileException if template file is invalid
      * @throws TemplateCompilationException if template compilation fails and errors are not yet handled by compiler
      * @throws TemplateNotFoundException if template could not be found
@@ -304,7 +298,6 @@ class HandlebarsRenderer implements RendererInterface, HelperAwareInterface, Log
 
     /**
      * @param array<mixed, mixed> $defaultData
-     * @return self
      */
     public function setDefaultData(array $defaultData): self
     {

--- a/Classes/Renderer/HandlebarsRenderer.php
+++ b/Classes/Renderer/HandlebarsRenderer.php
@@ -195,7 +195,7 @@ class HandlebarsRenderer implements RendererInterface, HelperAwareInterface, Log
             throw new TemplateCompilationException(
                 sprintf(
                     'Error during template compilation: "%s"',
-                    implode('", "', is_array($errors) ? $errors : [$errors])
+                    implode('", "', \is_array($errors) ? $errors : [$errors])
                 ),
                 1614620212
             );
@@ -249,7 +249,7 @@ class HandlebarsRenderer implements RendererInterface, HelperAwareInterface, Log
         GeneralUtility::unlink_tempfile($path);
 
         // Validate callable
-        if (!is_callable($callable)) {
+        if (!\is_callable($callable)) {
             throw new TemplateCompilationException('Got invalid compile result from compiler.', 1639405571);
         }
 

--- a/Classes/Renderer/Helper/VarDumpHelper.php
+++ b/Classes/Renderer/Helper/VarDumpHelper.php
@@ -33,7 +33,6 @@ class VarDumpHelper implements HelperInterface
 {
     /**
      * @param array<mixed, mixed> $context
-     * @return string
      */
     public static function evaluate(array $context): string
     {

--- a/Classes/Renderer/HelperAwareInterface.php
+++ b/Classes/Renderer/HelperAwareInterface.php
@@ -41,7 +41,6 @@ interface HelperAwareInterface
     /**
      * Register new Handlebars helper with given function.
      *
-     * @param string $name
      * @param mixed $function
      */
     public function registerHelper(string $name, $function): void;

--- a/Classes/Renderer/RendererInterface.php
+++ b/Classes/Renderer/RendererInterface.php
@@ -32,9 +32,7 @@ namespace Fr\Typo3Handlebars\Renderer;
 interface RendererInterface
 {
     /**
-     * @param string $templatePath
      * @param array<mixed, mixed> $data
-     * @return string
      */
     public function render(string $templatePath, array $data = []): string;
 }

--- a/Classes/Renderer/Template/HandlebarsTemplateResolver.php
+++ b/Classes/Renderer/Template/HandlebarsTemplateResolver.php
@@ -47,7 +47,6 @@ class HandlebarsTemplateResolver implements TemplateResolverInterface
     protected $supportedFileExtensions;
 
     /**
-     * @param TemplatePaths $templateRootPaths
      * @param string[] $supportedFileExtensions
      */
     public function __construct(TemplatePaths $templateRootPaths, array $supportedFileExtensions = self::DEFAULT_FILE_EXTENSIONS)

--- a/Classes/Renderer/Template/HandlebarsTemplateResolver.php
+++ b/Classes/Renderer/Template/HandlebarsTemplateResolver.php
@@ -112,7 +112,7 @@ class HandlebarsTemplateResolver implements TemplateResolverInterface
 
     public function supports(string $fileExtension): bool
     {
-        return in_array($fileExtension, $this->supportedFileExtensions, true);
+        return \in_array($fileExtension, $this->supportedFileExtensions, true);
     }
 
     public function resolveTemplatePath(string $templatePath): string
@@ -139,7 +139,7 @@ class HandlebarsTemplateResolver implements TemplateResolverInterface
         } else {
             $filename = $templatePath;
         }
-        if ($extension !== null && !in_array(pathinfo($filename, PATHINFO_EXTENSION), $this->supportedFileExtensions)) {
+        if ($extension !== null && !\in_array(pathinfo($filename, PATHINFO_EXTENSION), $this->supportedFileExtensions)) {
             $filename .= '.' . $extension;
         }
         $filename = GeneralUtility::getFileAbsFileName($filename);
@@ -151,9 +151,9 @@ class HandlebarsTemplateResolver implements TemplateResolverInterface
      */
     protected function validateTemplateRootPath($templateRootPath): void
     {
-        if (!is_string($templateRootPath)) {
+        if (!\is_string($templateRootPath)) {
             throw new \InvalidArgumentException(
-                sprintf('Template root path must be of type string, "%s" given.', gettype($templateRootPath)),
+                sprintf('Template root path must be of type string, "%s" given.', \gettype($templateRootPath)),
                 1613727984
             );
         }
@@ -170,9 +170,9 @@ class HandlebarsTemplateResolver implements TemplateResolverInterface
      */
     protected function validateFileExtension($fileExtension): void
     {
-        if (!is_string($fileExtension)) {
+        if (!\is_string($fileExtension)) {
             throw new \InvalidArgumentException(
-                sprintf('File extension must be of type string, "%s" given.', gettype($fileExtension)),
+                sprintf('File extension must be of type string, "%s" given.', \gettype($fileExtension)),
                 1613727952
             );
         }

--- a/Classes/Renderer/Template/TemplatePaths.php
+++ b/Classes/Renderer/Template/TemplatePaths.php
@@ -96,7 +96,7 @@ class TemplatePaths implements ContainerAwareInterface
         $parameterName = 'handlebars.' . $type;
         $templatePathsParameter = $this->container->getParameter($parameterName);
 
-        return is_array($templatePathsParameter) ? $templatePathsParameter : [$templatePathsParameter];
+        return \is_array($templatePathsParameter) ? $templatePathsParameter : [$templatePathsParameter];
     }
 
     /**

--- a/Classes/Renderer/Template/TemplatePaths.php
+++ b/Classes/Renderer/Template/TemplatePaths.php
@@ -57,10 +57,6 @@ class TemplatePaths implements ContainerAwareInterface
      */
     protected $templatePaths;
 
-    /**
-     * @param ConfigurationManagerInterface $configurationManager
-     * @param string $type
-     */
     public function __construct(ConfigurationManagerInterface $configurationManager, string $type = self::TEMPLATES)
     {
         $this->configurationManager = $configurationManager;
@@ -88,7 +84,6 @@ class TemplatePaths implements ContainerAwareInterface
     }
 
     /**
-     * @param string $type
      * @return string[]
      */
     protected function getTemplatePathsFromContainer(string $type): array
@@ -100,7 +95,6 @@ class TemplatePaths implements ContainerAwareInterface
     }
 
     /**
-     * @param string $type
      * @return string[]
      */
     protected function getTemplatePathsFromTypoScriptConfiguration(string $type): array

--- a/Classes/Traits/HandlebarsHelperTrait.php
+++ b/Classes/Traits/HandlebarsHelperTrait.php
@@ -88,31 +88,31 @@ trait HandlebarsHelperTrait
         $className = null;
         $methodName = null;
 
-        if (is_string($function) && !str_contains($function, '::')) {
+        if (\is_string($function) && !str_contains($function, '::')) {
             // 1. callable
-            if (is_callable($function)) {
+            if (\is_callable($function)) {
                 return $function;
             }
 
             // 2a. invokable class as string
-            if (class_exists($function) && is_callable($callable = GeneralUtility::makeInstance($function))) {
+            if (class_exists($function) && \is_callable($callable = GeneralUtility::makeInstance($function))) {
                 return $callable;
             }
         }
 
         // 2b. invokable class as object
-        if (is_object($function) && is_callable($function)) {
+        if (\is_object($function) && \is_callable($function)) {
             return $function;
         }
 
         // 3a. class method as string
-        if (is_string($function) && str_contains($function, '::')) {
+        if (\is_string($function) && str_contains($function, '::')) {
             [$className, $methodName] = explode('::', $function, 2);
         }
 
         // 3b. class method as array
         // 3c. class method as initialized array
-        if (is_array($function) && 2 === count($function)) {
+        if (\is_array($function) && 2 === \count($function)) {
             [$className, $methodName] = $function;
         }
 
@@ -130,18 +130,18 @@ trait HandlebarsHelperTrait
 
         // Check if method can be called statically
         $callable = [$className, $methodName];
-        if ($reflectionMethod->isStatic() && is_callable($callable)) {
+        if ($reflectionMethod->isStatic() && \is_callable($callable)) {
             return $callable;
         }
 
         // Instantiate class if not done yet
         /** @var class-string $className */
-        if (is_string($className)) {
+        if (\is_string($className)) {
             $className = GeneralUtility::makeInstance($className);
         }
 
         $callable = [$className, $methodName];
-        if (is_callable($callable)) {
+        if (\is_callable($callable)) {
             return $callable;
         }
 

--- a/Classes/Traits/HandlebarsHelperTrait.php
+++ b/Classes/Traits/HandlebarsHelperTrait.php
@@ -41,7 +41,6 @@ trait HandlebarsHelperTrait
     protected $helpers = [];
 
     /**
-     * @param string $name
      * @param mixed $function
      */
     public function registerHelper(string $name, $function): void
@@ -68,7 +67,6 @@ trait HandlebarsHelperTrait
 
     /**
      * @param mixed $function
-     * @return callable
      * @throws InvalidHelperException
      * @throws \ReflectionException
      */
@@ -150,7 +148,6 @@ trait HandlebarsHelperTrait
 
     /**
      * @param mixed $helperFunction
-     * @return bool
      * @codeCoverageIgnore
      * @deprecated use resolveHelperFunction() instead and check for thrown exceptions
      */

--- a/Tests/Unit/DataProcessing/AbstractDataProcessorTest.php
+++ b/Tests/Unit/DataProcessing/AbstractDataProcessorTest.php
@@ -97,7 +97,7 @@ class AbstractDataProcessorTest extends UnitTestCase
 
         self::assertSame('', $this->subject->process('', []));
         self::assertTrue($this->logger->hasCriticalThatPasses(function ($logRecord) {
-            $expectedMessage = 'Data processing for ' . get_class($this->subject) . ' failed.';
+            $expectedMessage = 'Data processing for ' . \get_class($this->subject) . ' failed.';
             static::assertSame($expectedMessage, $logRecord['message']);
             static::assertInstanceOf(UnableToPresentException::class, $logRecord['context']['exception']);
             return true;

--- a/Tests/Unit/DataProcessing/SimpleProcessorTest.php
+++ b/Tests/Unit/DataProcessing/SimpleProcessorTest.php
@@ -94,7 +94,7 @@ class SimpleProcessorTest extends UnitTestCase
     {
         self::assertSame('', $this->subject->process('', $configuration));
         self::assertTrue($this->logger->hasCriticalThatPasses(function ($logRecord) {
-            $expectedMessage = 'Data processing for ' . get_class($this->subject) . ' failed.';
+            $expectedMessage = 'Data processing for ' . \get_class($this->subject) . ' failed.';
             static::assertSame($expectedMessage, $logRecord['message']);
             static::assertInstanceOf(InvalidTemplateFileException::class, $logRecord['context']['exception']);
             static::assertSame(1606834398, $logRecord['context']['exception']->getCode());

--- a/Tests/Unit/Fixtures/Classes/Cache/DummyCache.php
+++ b/Tests/Unit/Fixtures/Classes/Cache/DummyCache.php
@@ -56,7 +56,7 @@ class DummyCache implements CacheInterface
     public function set(string $template, string $compileResult): void
     {
         $cacheFile = $this->resolveCacheFile($template);
-        GeneralUtility::mkdir_deep(dirname($cacheFile));
+        GeneralUtility::mkdir_deep(\dirname($cacheFile));
         file_put_contents($cacheFile, $compileResult);
     }
 

--- a/Tests/Unit/Fixtures/Classes/Renderer/Template/DummyTemplatePaths.php
+++ b/Tests/Unit/Fixtures/Classes/Renderer/Template/DummyTemplatePaths.php
@@ -36,7 +36,6 @@ final class DummyTemplatePaths extends TemplatePaths
 {
     /**
      * @param string[] $templatePaths
-     * @return self
      */
     public function setTemplatePaths(array $templatePaths): self
     {

--- a/Tests/Unit/Fixtures/Classes/Traits/DummyContentObjectRendererAwareTraitClass.php
+++ b/Tests/Unit/Fixtures/Classes/Traits/DummyContentObjectRendererAwareTraitClass.php
@@ -36,9 +36,6 @@ final class DummyContentObjectRendererAwareTraitClass
 {
     use ContentObjectRendererAwareTrait;
 
-    /**
-     * @return ContentObjectRenderer|null
-     */
     public function getContentObjectRenderer(): ?ContentObjectRenderer
     {
         return $this->contentObjectRenderer;

--- a/Tests/Unit/Renderer/HandlebarsRendererTest.php
+++ b/Tests/Unit/Renderer/HandlebarsRendererTest.php
@@ -319,7 +319,6 @@ class HandlebarsRendererTest extends UnitTestCase
 
     /**
      * @param class-string<HandlebarsRenderer> $rendererClass
-     * @return HandlebarsRenderer
      */
     protected function renewSubject(string $rendererClass = HandlebarsRenderer::class): HandlebarsRenderer
     {

--- a/Tests/Unit/Renderer/Template/HandlebarsTemplateResolverTest.php
+++ b/Tests/Unit/Renderer/Template/HandlebarsTemplateResolverTest.php
@@ -181,7 +181,7 @@ class HandlebarsTemplateResolverTest extends UnitTestCase
      */
     public function resolveTemplatePathResolvesAbsoluteTemplatePathCorrectly(): void
     {
-        $templatePath = dirname(__DIR__, 2) . '/Fixtures/Templates/DummyTemplate.hbs';
+        $templatePath = \dirname(__DIR__, 2) . '/Fixtures/Templates/DummyTemplate.hbs';
         $expected = $this->getTemplateRootPath() . '/DummyTemplate.hbs';
 
         self::assertSame($expected, $this->subject->resolveTemplatePath($templatePath));

--- a/Tests/Unit/Traits/ErrorHandlingTraitTest.php
+++ b/Tests/Unit/Traits/ErrorHandlingTraitTest.php
@@ -63,7 +63,7 @@ class ErrorHandlingTraitTest extends UnitTestCase
 
         $this->subject->doHandleError($exception);
         self::assertTrue($this->logger->hasCriticalThatPasses(function ($logRecord) use ($exception) {
-            $expectedMessage = 'Data processing for ' . get_class($this->subject) . ' failed.';
+            $expectedMessage = 'Data processing for ' . \get_class($this->subject) . ' failed.';
             static::assertSame($expectedMessage, $logRecord['message']);
             static::assertSame($exception, $logRecord['context']['exception']);
             return true;

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -1,6 +1,6 @@
 <?php
 
-defined('TYPO3') or die();
+\defined('TYPO3') or die();
 
 /*
  * This file is part of the TYPO3 CMS extension "handlebars".


### PR DESCRIPTION
This PR enables and applies the following PHP-CS-Fixer rules:

- [x] `native_function_invocation`
- [x] `no_superfluous_phpdoc_tags`