### PR TITLE
[BUGFIX] Resolve PHPStan issue phpstan/phpstan#7020

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
 		"jangregor/phpstan-prophecy": "^1.0",
 		"mikey179/vfsstream": "^1.6",
 		"phpspec/prophecy-phpunit": "^2.0",
-		"phpstan/phpstan": "^1.2",
+		"phpstan/phpstan": "^1.5.5",
 		"phpstan/phpstan-phpunit": "^1.1",
 		"phpunit/phpunit": "^9.5",
 		"saschaegerer/phpstan-typo3": "^1.0",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,6 +1,0 @@
-parameters:
-    ignoreErrors:
-        -
-            message: "#^Method Fr\\\\Typo3Handlebars\\\\Renderer\\\\Template\\\\TemplatePaths\\:\\:mergeTemplatePaths\\(\\) should return array\\<string\\> but returns array\\<int|string, array\\<string\\>\\>\\.$#"
-            count: 1
-            path: Classes/Renderer/Template/TemplatePaths.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,4 @@
 includes:
-    - phpstan-baseline.neon
     - .Build/vendor/jangregor/phpstan-prophecy/extension.neon
     - .Build/vendor/phpstan/phpstan-phpunit/extension.neon
     - .Build/vendor/saschaegerer/phpstan-typo3/extension.neon


### PR DESCRIPTION
Issue phpstan/phpstan#7020 was resolved with PHPStan 1.5.5. Therefore, this is now the minimum installable version of PHPStan.