### PR TITLE
[DOCS] Align with new documentation standard

### DIFF
--- a/Documentation/Compatibility/ExtbaseControllers.rst
+++ b/Documentation/Compatibility/ExtbaseControllers.rst
@@ -1,4 +1,4 @@
-.. include:: ../Includes.txt
+.. include:: /Includes.rst.txt
 
 .. _extbase-controllers:
 

--- a/Documentation/Compatibility/ExtbaseRepositories.rst
+++ b/Documentation/Compatibility/ExtbaseRepositories.rst
@@ -1,4 +1,4 @@
-.. include:: ../Includes.txt
+.. include:: /Includes.rst.txt
 
 .. _extbase-repositories:
 

--- a/Documentation/Compatibility/Index.rst
+++ b/Documentation/Compatibility/Index.rst
@@ -1,4 +1,4 @@
-.. include:: ../Includes.txt
+.. include:: /Includes.rst.txt
 
 .. _compatibility:
 

--- a/Documentation/Configuration/Cache/Index.rst
+++ b/Documentation/Configuration/Cache/Index.rst
@@ -1,4 +1,4 @@
-.. include:: ../../Includes.txt
+.. include:: /Includes.rst.txt
 
 .. _cache:
 

--- a/Documentation/Configuration/Debugging/Index.rst
+++ b/Documentation/Configuration/Debugging/Index.rst
@@ -1,4 +1,4 @@
-.. include:: ../../Includes.txt
+.. include:: /Includes.rst.txt
 
 .. _debugging:
 

--- a/Documentation/Configuration/DefaultData/Index.rst
+++ b/Documentation/Configuration/DefaultData/Index.rst
@@ -1,4 +1,4 @@
-.. include:: ../../Includes.txt
+.. include:: /Includes.rst.txt
 
 .. _default-data:
 

--- a/Documentation/Configuration/Index.rst
+++ b/Documentation/Configuration/Index.rst
@@ -1,4 +1,4 @@
-.. include:: ../Includes.txt
+.. include:: /Includes.rst.txt
 
 .. _configuration:
 

--- a/Documentation/Configuration/TemplatePaths/Index.rst
+++ b/Documentation/Configuration/TemplatePaths/Index.rst
@@ -1,4 +1,4 @@
-.. include:: ../../Includes.txt
+.. include:: /Includes.rst.txt
 
 .. _template-paths:
 

--- a/Documentation/Contributing/Index.rst
+++ b/Documentation/Contributing/Index.rst
@@ -1,4 +1,4 @@
-.. include:: ../Includes.txt
+.. include:: /Includes.rst.txt
 
 .. _contributing:
 

--- a/Documentation/Includes.rst.txt
+++ b/Documentation/Includes.rst.txt
@@ -1,4 +1,4 @@
-.. This is 'Includes.txt'. It is included at the very top of each and
+.. This is 'Includes.rst.txt'. It is included at the very top of each and
    every ReST source file in THIS documentation project (= manual).
 
 .. role:: aspect (emphasis)

--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -1,4 +1,4 @@
-.. include:: Includes.txt
+.. include:: /Includes.rst.txt
 
 .. _start:
 
@@ -54,4 +54,9 @@ Contents
    RenderingConcept/Index
    Compatibility/Index
    Contributing/Index
+
+.. toctree::
+   :hidden:
+
    Sitemap
+   genindex

--- a/Documentation/Installation/Index.rst
+++ b/Documentation/Installation/Index.rst
@@ -1,4 +1,4 @@
-.. include:: ../Includes.txt
+.. include:: /Includes.rst.txt
 
 .. _installation:
 

--- a/Documentation/Introduction/Index.rst
+++ b/Documentation/Introduction/Index.rst
@@ -1,4 +1,4 @@
-.. include:: ../Includes.txt
+.. include:: /Includes.rst.txt
 
 .. _introduction:
 

--- a/Documentation/RenderingConcept/Index.rst
+++ b/Documentation/RenderingConcept/Index.rst
@@ -1,4 +1,4 @@
-.. include:: ../Includes.txt
+.. include:: /Includes.rst.txt
 
 .. _rendering-concept:
 

--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -1,15 +1,16 @@
 [general]
 project = Handlebars
 release = 0.7.13
-copyright = by coding. powerful. systems. CPS GmbH
+copyright = since 2020 by coding. powerful. systems. CPS GmbH
 author = Elias Häußler
 
 [html_theme_options]
+project_home = https://extensions.typo3.org/extension/handlebars
 project_contact = e.haeussler@familie-redlich.de
 project_issues = https://github.com/CPS-IT/handlebars/issues
 github_branch = main
 github_repository = CPS-IT/handlebars
-project_repository = https://github.com/CPS-IT/handlebars.git
+project_repository = https://github.com/CPS-IT/handlebars
 
 [intersphinx_mapping]
 t3coreapi = https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/

--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -6,7 +6,7 @@ author = Elias Häußler
 
 [html_theme_options]
 project_home = https://extensions.typo3.org/extension/handlebars
-project_contact = e.haeussler@familie-redlich.de
+project_contact = https://typo3.slack.com/archives/C0281DBRFCZ
 project_issues = https://github.com/CPS-IT/handlebars/issues
 github_branch = main
 github_repository = CPS-IT/handlebars

--- a/Documentation/Sitemap.rst
+++ b/Documentation/Sitemap.rst
@@ -1,7 +1,9 @@
 :template: sitemap.html
 
-.. _sitemap:
+.. include:: /Includes.rst.txt
 
 =======
 Sitemap
 =======
+
+.. The sitemap.html template will insert here the page tree automatically.

--- a/Documentation/Usage/Basic/Index.rst
+++ b/Documentation/Usage/Basic/Index.rst
@@ -1,4 +1,4 @@
-.. include:: ../../Includes.txt
+.. include:: /Includes.rst.txt
 
 .. _basic-usage:
 

--- a/Documentation/Usage/Extended/CreateACustomHelper/Index.rst
+++ b/Documentation/Usage/Extended/CreateACustomHelper/Index.rst
@@ -1,4 +1,4 @@
-.. include:: ../../../Includes.txt
+.. include:: /Includes.rst.txt
 
 .. _create-a-custom-helper:
 

--- a/Documentation/Usage/Extended/CustomRenderingComponents/Index.rst
+++ b/Documentation/Usage/Extended/CustomRenderingComponents/Index.rst
@@ -1,4 +1,4 @@
-.. include:: ../../../Includes.txt
+.. include:: /Includes.rst.txt
 
 .. _custom-rendering-components:
 

--- a/Documentation/Usage/Extended/Events/Index.rst
+++ b/Documentation/Usage/Extended/Events/Index.rst
@@ -1,4 +1,4 @@
-.. include:: ../../../Includes.txt
+.. include:: /Includes.rst.txt
 
 .. _events:
 

--- a/Documentation/Usage/Extended/Index.rst
+++ b/Documentation/Usage/Extended/Index.rst
@@ -1,4 +1,4 @@
-.. include:: ../../Includes.txt
+.. include:: /Includes.rst.txt
 
 .. _extended-usage:
 

--- a/Documentation/Usage/Extended/SharedComponents/Index.rst
+++ b/Documentation/Usage/Extended/SharedComponents/Index.rst
@@ -1,4 +1,4 @@
-.. include:: ../../../Includes.txt
+.. include:: /Includes.rst.txt
 
 .. _shared-components:
 

--- a/Documentation/Usage/Extended/SimpleProcessor/Index.rst
+++ b/Documentation/Usage/Extended/SimpleProcessor/Index.rst
@@ -1,4 +1,4 @@
-.. include:: ../../../Includes.txt
+.. include:: /Includes.rst.txt
 
 .. _simple-processor:
 

--- a/Documentation/Usage/Extended/UsingTheContentObjectRenderer/Index.rst
+++ b/Documentation/Usage/Extended/UsingTheContentObjectRenderer/Index.rst
@@ -1,4 +1,4 @@
-.. include:: ../../../Includes.txt
+.. include:: /Includes.rst.txt
 
 .. _using-the-content-object-renderer:
 

--- a/Documentation/Usage/Index.rst
+++ b/Documentation/Usage/Index.rst
@@ -1,4 +1,4 @@
-.. include:: ../Includes.txt
+.. include:: /Includes.rst.txt
 
 .. _usage:
 

--- a/Documentation/genindex.rst
+++ b/Documentation/genindex.rst
@@ -1,0 +1,7 @@
+.. include:: /Includes.rst.txt
+
+=====
+Index
+=====
+
+.. Sphinx will insert here the general index automatically.


### PR DESCRIPTION
This PR aligns the project documentation with the new documentation standard, see https://typo3.org/article/standardization-of-typo3-documentation-may-2022.