### PR TITLE
[BUGFIX] Assure compatiblity with PHP 8.1 in SimpleProviderResponse

### DIFF
--- a/Classes/Data/Response/SimpleProviderResponse.php
+++ b/Classes/Data/Response/SimpleProviderResponse.php
@@ -51,6 +51,7 @@ class SimpleProviderResponse implements ProviderResponseInterface, \ArrayAccess
         return \array_key_exists($offset, $this->data);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         if ($this->offsetExists($offset)) {


### PR DESCRIPTION
Since the codebase still supports older PHP versions, we cannot fully reflect PHP 8.1 changes in method signatures and therefore add the `ReturnTypeWillChange` attribute.