### PR TITLE
[TASK] Use ramsey/composer-install in test workflow

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,14 +10,14 @@ on:
 
 jobs:
   tests:
-    name: Tests (PHP ${{ matrix.php-version }}, TYPO3 ${{ matrix.typo3-version }} & ${{ matrix.preferred-install }} dependencies)
+    name: Tests (PHP ${{ matrix.php-version }}, TYPO3 ${{ matrix.typo3-version }} & ${{ matrix.dependencies }} dependencies)
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         typo3-version: ["10.4", "11.5"]
         php-version: ["7.4", "8.0", "8.1"]
-        preferred-install: ["stable", "lowest"]
+        dependencies: ["highest", "lowest"]
         exclude:
           - typo3-version: "10.4"
             php-version: "8.0"
@@ -36,22 +36,12 @@ jobs:
           tools: composer:v2
           coverage: none
 
-      # Define Composer cache
-      - name: Get Composer cache directory
-        id: composer-cache
-        run: |
-          echo "::set-output name=dir::$(composer config cache-files-dir)"
-      - name: Define Composer cache
-        uses: actions/cache@v3
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: tests-php-${{ matrix.php-version }}-typo3-${{ matrix.typo3-version }}
-          restore-keys: |
-            tests-php-${{ matrix.php-version }}-typo3-
-
       # Install dependencies
-      - name: Install TYPO3 and Composer dependencies
-        run: composer require typo3/cms-core:"^${{ matrix.typo3-version }}" --no-progress --prefer-${{ matrix.preferred-install }}
+      - name: Install Composer dependencies
+        uses: ramsey/composer-install@v2
+        with:
+          dependency-versions: ${{ matrix.dependencies }}
+          composer-options: --with=typo3/cms-core:"~${{ matrix.typo3-version }}.0"
 
       # Run tests
       - name: Run tests
@@ -73,22 +63,9 @@ jobs:
           tools: composer:v2
           coverage: pcov
 
-      # Define Composer cache
-      - name: Get Composer cache directory
-        id: composer-cache
-        run: |
-          echo "::set-output name=dir::$(composer config cache-files-dir)"
-      - name: Define Composer cache
-        uses: actions/cache@v3
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: tests-php-8.1-typo3-11.5
-          restore-keys: |
-            tests-php-8.1-typo3-
-
       # Install dependencies
-      - name: Install TYPO3 and Composer dependencies
-        run: composer update --no-progress
+      - name: Install Composer dependencies
+        uses: ramsey/composer-install@v2
 
       # Run tests
       - name: Run tests


### PR DESCRIPTION
With this PR, the `ramsey/composer-install` action is now used to install Composer dependencies in the test workflow.