### PR TITLE
[DOCS] Fix indentations in documentation

### DIFF
--- a/Documentation/Compatibility/ExtbaseControllers.rst
+++ b/Documentation/Compatibility/ExtbaseControllers.rst
@@ -1,21 +1,21 @@
-.. include:: /Includes.rst.txt
+..  include:: /Includes.rst.txt
 
-.. _extbase-controllers:
+..  _extbase-controllers:
 
 ===================
 Extbase controllers
 ===================
 
-.. versionadded:: 0.7.0
+..  versionadded:: 0.7.0
 
-   `Feature: #18 - Provide view adapter for extbase controllers <https://github.com/CPS-IT/handlebars/pull/18>`__
+    `Feature: #18 - Provide view adapter for extbase controllers <https://github.com/CPS-IT/handlebars/pull/18>`__
 
 In order to increase compatibility with standard extbase plugins,
 the extension supports the rendering of extbase controller actions.
 For this purpose, a compatibility layer was introduced, with which
 own `DataProcessors` can be triggered using the :php:`HandlebarsViewResolver`.
 
-.. _extbase-controllers-configuration:
+..  _extbase-controllers-configuration:
 
 Configuration
 =============
@@ -24,30 +24,30 @@ Tag each `DataProcessor` with `handlebars.compatibility_layer` within
 your :file:`Services.yaml` file and provide additional information
 about the target extbase controller and actions supported by it.
 
-.. code-block:: yaml
+..  code-block:: yaml
 
-   # Configuration/Services.yaml
+    # Configuration/Services.yaml
 
-   services:
-     Vendor\Extension\DataProcessing\MyProcessor:
-       tags:
-         - name: handlebars.processor
-         - name: handlebars.compatibility_layer
-           controller: 'Vendor\Extension\Controller\MyController'
-           actions: 'dummy'
+    services:
+      Vendor\Extension\DataProcessing\MyProcessor:
+        tags:
+          - name: handlebars.processor
+          - name: handlebars.compatibility_layer
+            controller: 'Vendor\Extension\Controller\MyController'
+            actions: 'dummy'
 
 The `action` configuration can be either empty (= `NULL`) or set
 to a comma-separated list of action names that are supported by the
 configured `DataProcessor`. If you leave it empty, the `DataProcessor`
 is used for all controller actions.
 
-.. important::
+..  important::
 
-   Only `DataProcessors` that are additionally tagged with
-   `handlebars.processor` are respected as component for additional
-   compatibility layers.
+    Only `DataProcessors` that are additionally tagged with
+    `handlebars.processor` are respected as component for additional
+    compatibility layers.
 
-.. _extbase-controllers-usage:
+..  _extbase-controllers-usage:
 
 Usage
 =====
@@ -62,24 +62,24 @@ When accessing the :php:`$configuration` property inside your
 
 ::
 
-   $configuration = [
-       'extbaseViewConfiguration' => [
-           'controller' => '<controller class>',
-           'action' => '<controller action>',
-           'request' => '<original extbase request>',
-           'variables' => '<template variables>',
-       ],
-   ];
+    $configuration = [
+        'extbaseViewConfiguration' => [
+            'controller' => '<controller class>',
+            'action' => '<controller action>',
+            'request' => '<original extbase request>',
+            'variables' => '<template variables>',
+        ],
+    ];
 
-.. _extbase-controllers-sources:
+..  _extbase-controllers-sources:
 
 Sources
 =======
 
-.. seealso::
+..  seealso::
 
-   View the sources on GitHub:
+    View the sources on GitHub:
 
-   -  `ExtbaseViewAdapter <https://github.com/CPS-IT/handlebars/blob/main/Classes/Compatibility/View/ExtbaseViewAdapter.php>`__
-   -  `HandlebarsViewResolver <https://github.com/CPS-IT/handlebars/blob/main/Classes/Compatibility/View/HandlebarsViewResolver.php>`__
-   -  `ExtbaseControllerCompatibilityLayer <https://github.com/CPS-IT/handlebars/blob/main/Classes/DependencyInjection/Compatibility/ExtbaseControllerCompatibilityLayer.php>`__
+    - `ExtbaseViewAdapter <https://github.com/CPS-IT/handlebars/blob/main/Classes/Compatibility/View/ExtbaseViewAdapter.php>`__
+    - `HandlebarsViewResolver <https://github.com/CPS-IT/handlebars/blob/main/Classes/Compatibility/View/HandlebarsViewResolver.php>`__
+    - `ExtbaseControllerCompatibilityLayer <https://github.com/CPS-IT/handlebars/blob/main/Classes/DependencyInjection/Compatibility/ExtbaseControllerCompatibilityLayer.php>`__

--- a/Documentation/Compatibility/ExtbaseRepositories.rst
+++ b/Documentation/Compatibility/ExtbaseRepositories.rst
@@ -1,22 +1,22 @@
-.. include:: /Includes.rst.txt
+..  include:: /Includes.rst.txt
 
-.. _extbase-repositories:
+..  _extbase-repositories:
 
 ====================
 Extbase repositories
 ====================
 
-.. versionadded:: 0.7.3
+..  versionadded:: 0.7.3
 
-   `Feature: #23 - Provide compatibility method for Extbase repositories <https://github.com/CPS-IT/handlebars/pull/23>`__
+    `Feature: #23 - Provide compatibility method for Extbase repositories <https://github.com/CPS-IT/handlebars/pull/23>`__
 
-.. warning::
+..  warning::
 
-   **Use of the** `AbstractDataProcessor` **required**
+    **Use of the** `AbstractDataProcessor` **required**
 
-   This compatibility method is only applicable to `DataProcessors`
-   that extend the :php:`AbstractDataProcessor`, since it provides the
-   necessary method. It is not part of the :php:`DataProcessorInterface`.
+    This compatibility method is only applicable to `DataProcessors`
+    that extend the :php:`AbstractDataProcessor`, since it provides the
+    necessary method. It is not part of the :php:`DataProcessorInterface`.
 
 When Extbase repositories are used to fetch data via the `DataProvider`,
 it may be necessary to perform the necessary bootstrapping for Extbase
@@ -31,36 +31,36 @@ To execute the necessary bootstrapping or to reset the underlying
 :php:`initializeConfigurationManager()` must be executed in the
 `DataProcessor`.
 
-.. _extbase-repositories-usage:
+..  _extbase-repositories-usage:
 
 Usage
 =====
 
-.. code-block:: diff
+..  code-block:: diff
 
-    # Classes/DataProcessing/HeaderProcessor.php
+     # Classes/DataProcessing/HeaderProcessor.php
 
-    namespace Vendor\Extension\DataProcessing;
+     namespace Vendor\Extension\DataProcessing;
 
-    use Fr\Typo3Handlebars\DataProcessing\AbstractDataProcessor;
+     use Fr\Typo3Handlebars\DataProcessing\AbstractDataProcessor;
 
-    class HeaderProcessor extends AbstractDataProcessor
-    {
-        protected function render(): string
-        {
-   +        $this->initializeConfigurationManager();
-            $data = $this->provider->get($this->cObj->data);
-            return $this->presenter->present($data);
-        }
-    }
+     class HeaderProcessor extends AbstractDataProcessor
+     {
+         protected function render(): string
+         {
+    +        $this->initializeConfigurationManager();
+             $data = $this->provider->get($this->cObj->data);
+             return $this->presenter->present($data);
+         }
+     }
 
-.. _extbase-repositories-sources:
+..  _extbase-repositories-sources:
 
 Sources
 =======
 
-.. seealso::
+..  seealso::
 
-   View the sources on GitHub:
+    View the sources on GitHub:
 
-   -  `AbstractDataProcessor <https://github.com/CPS-IT/handlebars/blob/main/Classes/DataProcessing/AbstractDataProcessor.php>`__
+    - `AbstractDataProcessor <https://github.com/CPS-IT/handlebars/blob/main/Classes/DataProcessing/AbstractDataProcessor.php>`__

--- a/Documentation/Compatibility/Index.rst
+++ b/Documentation/Compatibility/Index.rst
@@ -1,6 +1,6 @@
-.. include:: /Includes.rst.txt
+..  include:: /Includes.rst.txt
 
-.. _compatibility:
+..  _compatibility:
 
 =============
 Compatibility
@@ -9,8 +9,8 @@ Compatibility
 This section shows which possibilities the extension provides
 for compatibility with other TYPO3 components.
 
-.. toctree::
-   :maxdepth: 1
+..  toctree::
+    :maxdepth: 1
 
-   ExtbaseControllers
-   ExtbaseRepositories
+    ExtbaseControllers
+    ExtbaseRepositories

--- a/Documentation/Configuration/Cache/Index.rst
+++ b/Documentation/Configuration/Cache/Index.rst
@@ -1,6 +1,6 @@
-.. include:: /Includes.rst.txt
+..  include:: /Includes.rst.txt
 
-.. _cache:
+..  _cache:
 
 =====
 Cache
@@ -15,14 +15,14 @@ You can specify a different cache backend as follows:
 
 ::
 
-   # ext_localconf.php
+    # ext_localconf.php
 
-   if (!isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['handlebars']['backend'])) {
-       $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['handlebars']['backend']
-           = \TYPO3\CMS\Core\Cache\Backend\SimpleFileBackend::class;
-   }
+    if (!isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['handlebars']['backend'])) {
+        $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['handlebars']['backend']
+            = \TYPO3\CMS\Core\Cache\Backend\SimpleFileBackend::class;
+    }
 
-.. seealso::
+..  seealso::
 
-   Read more about cache configuration in the
-   :ref:`official TYPO3 documentation <t3coreapi:caching-configuration>`.
+    Read more about cache configuration in the
+    :ref:`official TYPO3 documentation <t3coreapi:caching-configuration>`.

--- a/Documentation/Configuration/Debugging/Index.rst
+++ b/Documentation/Configuration/Debugging/Index.rst
@@ -1,6 +1,6 @@
-.. include:: /Includes.rst.txt
+..  include:: /Includes.rst.txt
 
-.. _debugging:
+..  _debugging:
 
 =========
 Debugging
@@ -14,39 +14,39 @@ them more efficiently.
 Learn more in the
 `official documentation of LightnCandy <https://zordius.github.io/HandlebarsCookbook/LC-FLAG_RENDER_DEBUG.html>`__.
 
-.. warning::
+..  warning::
 
-   Note that debugging only applies in the default `Renderer`. If a custom
-   `Renderer` is implemented and used, then this functionality is not available
-   out of the box.
+    Note that debugging only applies in the default `Renderer`. If a custom
+    `Renderer` is implemented and used, then this functionality is not available
+    out of the box.
 
-.. _typoscript:
+..  _typoscript:
 
 TypoScript
 ==========
 
-.. seealso::
+..  seealso::
 
-   Read more about this TypoScript configuration in the
-   :ref:`official TYPO3 documentation <t3tsref:setup-config-debug>`.
+    Read more about this TypoScript configuration in the
+    :ref:`official TYPO3 documentation <t3tsref:setup-config-debug>`.
 
-.. code-block:: typoscript
+..  code-block:: typoscript
 
-   # Disable debugging
-   config.debug = 0
+    # Disable debugging
+    config.debug = 0
 
-   # Enable debugging
-   config.debug = 1
+    # Enable debugging
+    config.debug = 1
 
-.. _local-configuration:
+..  _local-configuration:
 
 Local configuration
 ===================
 
 ::
 
-   // Disable debugging
-   $GLOBALS['TYPO3_CONF_VARS']['FE']['debug'] = false;
+    // Disable debugging
+    $GLOBALS['TYPO3_CONF_VARS']['FE']['debug'] = false;
 
-   // Enable debugging
-   $GLOBALS['TYPO3_CONF_VARS']['FE']['debug'] = true;
+    // Enable debugging
+    $GLOBALS['TYPO3_CONF_VARS']['FE']['debug'] = true;

--- a/Documentation/Configuration/DefaultData/Index.rst
+++ b/Documentation/Configuration/DefaultData/Index.rst
@@ -1,6 +1,6 @@
-.. include:: /Includes.rst.txt
+..  include:: /Includes.rst.txt
 
-.. _default-data:
+..  _default-data:
 
 ============
 Default data
@@ -14,27 +14,27 @@ The standard `HandlebarsRenderer` provides the possibility to specify an
 array :php:`$defaultData` for this purpose. This data is merged with the
 concrete render data during each rendering and passed on to the `Renderer`.
 
-.. _configure-default-data:
+..  _configure-default-data:
 
 Configuration
 =============
 
 In your :file:`Services.yaml` file, add the following lines:
 
-.. code-block:: yaml
+..  code-block:: yaml
 
-   # Configuration/Services.yaml
+    # Configuration/Services.yaml
 
-   handlebars:
-     default_data:
-       publicPath: /assets
-       # ...
+    handlebars:
+      default_data:
+        publicPath: /assets
+        # ...
 
 All data will then be available as service parameter `%handlebars.default_data%`
 within the service container. So you can use it everywhere you need it in
 your :file:`Services.yaml` file.
 
-.. _overwrite-default-data:
+..  _overwrite-default-data:
 
 Overwrite default data
 ======================
@@ -44,24 +44,24 @@ it can simply be passed as an additional value in the `Presenter`:
 
 ::
 
-   # Classes/Presenter/MyCustomPresenter.php
+    # Classes/Presenter/MyCustomPresenter.php
 
-   namespace Vendor\Extension\Presenter;
+    namespace Vendor\Extension\Presenter;
 
-   use Fr\Typo3Handlebars\Data\Response\ProviderResponseInterface;
-   use Fr\Typo3Handlebars\Presenter\AbstractPresenter;
+    use Fr\Typo3Handlebars\Data\Response\ProviderResponseInterface;
+    use Fr\Typo3Handlebars\Presenter\AbstractPresenter;
 
-   class MyCustomPresenter extends AbstractPresenter
-   {
-       public function present(ProviderResponseInterface $data): string
-       {
-           $renderData = [
-               // ...
-           ];
+    class MyCustomPresenter extends AbstractPresenter
+    {
+        public function present(ProviderResponseInterface $data): string
+        {
+            $renderData = [
+                // ...
+            ];
 
-           // Overwrite default data "publicPath"
-           $renderData['publicPath'] = '/custom/path/to/assets';
+            // Overwrite default data "publicPath"
+            $renderData['publicPath'] = '/custom/path/to/assets';
 
-           return $this->renderer->render('path/to/template', $renderData);
-       }
-   }
+            return $this->renderer->render('path/to/template', $renderData);
+        }
+    }

--- a/Documentation/Configuration/Index.rst
+++ b/Documentation/Configuration/Index.rst
@@ -1,6 +1,6 @@
-.. include:: /Includes.rst.txt
+..  include:: /Includes.rst.txt
 
-.. _configuration:
+..  _configuration:
 
 =============
 Configuration
@@ -16,10 +16,10 @@ correctly.
 Learn here which configurations are necessary and learn more about
 how to use the extension:
 
-.. toctree::
-   :maxdepth: 3
+..  toctree::
+    :maxdepth: 3
 
-   Cache/Index
-   TemplatePaths/Index
-   DefaultData/Index
-   Debugging/Index
+    Cache/Index
+    TemplatePaths/Index
+    DefaultData/Index
+    Debugging/Index

--- a/Documentation/Configuration/TemplatePaths/Index.rst
+++ b/Documentation/Configuration/TemplatePaths/Index.rst
@@ -1,6 +1,6 @@
-.. include:: /Includes.rst.txt
+..  include:: /Includes.rst.txt
 
-.. _template-paths:
+..  _template-paths:
 
 ==============
 Template paths
@@ -9,29 +9,29 @@ Template paths
 There exist several ways to declare template root paths and partial root
 paths. The most relevant ones are described below.
 
-.. _configuration-via-service-container:
+..  _configuration-via-service-container:
 
 Configuration via service container
 ===================================
 
-.. attention::
+..  attention::
 
-   Make sure you have defined :ref:`EXT:handlebars as dependency <define-dependencies>`
-   in your extension(s). Otherwise, template root paths might not be interpreted correctly.
+    Make sure you have defined :ref:`EXT:handlebars as dependency <define-dependencies>`
+    in your extension(s). Otherwise, template root paths might not be interpreted correctly.
 
 The easiest way to register your template root paths and partial root paths
 is by using the :file:`Services.yaml` file:
 
-.. code-block:: yaml
+..  code-block:: yaml
 
-   # Configuration/Services.yaml
+    # Configuration/Services.yaml
 
-   handlebars:
-     template:
-       template_root_paths:
-         10: EXT:my_extension/Resources/Private/Templates
-       partial_root_paths:
-         10: EXT:my_extension/Resources/Private/Partials
+    handlebars:
+      template:
+        template_root_paths:
+          10: EXT:my_extension/Resources/Private/Templates
+        partial_root_paths:
+          10: EXT:my_extension/Resources/Private/Partials
 
 The `HandlebarsExtension`_
 takes care of all template paths. They will be merged and then added to the
@@ -49,39 +49,39 @@ In case you need different template paths for specific parts of your
 installation, take a look at the following configuration method that uses
 TypoScript.
 
-.. _configuration-via-typoscript:
+..  _configuration-via-typoscript:
 
 Configuration via TypoScript
 ============================
 
-.. versionadded:: 0.7.0
+..  versionadded:: 0.7.0
 
-   `Feature: #15 - Allow TypoScript as configuration for template paths <https://github.com/CPS-IT/handlebars/pull/15>`__
+    `Feature: #15 - Allow TypoScript as configuration for template paths <https://github.com/CPS-IT/handlebars/pull/15>`__
 
 A more flexible configuration method is the usage of TypoScript. This way you
 can override the configuration from the service container (as described above)
 which allows you to define different template root paths and partial root
 paths for specific parts of the system.
 
-.. code-block:: typoscript
+..  code-block:: typoscript
 
-   plugin.tx_handlebars {
-     view {
-       templateRootPaths {
-         20 = EXT:my_other_extension/Resources/Private/Templates
-       }
-       partialRootPaths {
-         20 = EXT:my_other_extension/Resources/Private/Partials
-       }
-     }
-   }
+    plugin.tx_handlebars {
+      view {
+        templateRootPaths {
+          20 = EXT:my_other_extension/Resources/Private/Templates
+        }
+        partialRootPaths {
+          20 = EXT:my_other_extension/Resources/Private/Partials
+        }
+      }
+    }
 
-.. note::
+..  note::
 
-   **Configuration of template paths in multiple extensions**
+    **Configuration of template paths in multiple extensions**
 
-   If template paths are defined multiple times (e.g. within various
-   extensions that provide Handlebars templates), the ones with the
-   same numeric key will be overridden by the last defined one.
+    If template paths are defined multiple times (e.g. within various
+    extensions that provide Handlebars templates), the ones with the
+    same numeric key will be overridden by the last defined one.
 
-.. _HandlebarsExtension: https://github.com/CPS-IT/handlebars/blob/main/Classes/DependencyInjection/Extension/HandlebarsExtension.php
+..  _HandlebarsExtension: https://github.com/CPS-IT/handlebars/blob/main/Classes/DependencyInjection/Extension/HandlebarsExtension.php

--- a/Documentation/Contributing/Index.rst
+++ b/Documentation/Contributing/Index.rst
@@ -1,6 +1,6 @@
-.. include:: /Includes.rst.txt
+..  include:: /Includes.rst.txt
 
-.. _contributing:
+..  _contributing:
 
 ============
 Contributing
@@ -16,7 +16,7 @@ To ensure the stability and cleanliness of the code, various code
 quality tools are used and most components are covered with test
 cases.
 
-.. _create-an-issue-first:
+..  _create-an-issue-first:
 
 Create an issue first
 =====================
@@ -27,102 +27,102 @@ GitHub: https://github.com/CPS-IT/handlebars/issues
 Also, please check if there is already an issue on the topic you want
 to address.
 
-.. _contribution-workflow:
+..  _contribution-workflow:
 
 Contribution workflow
 =====================
 
-.. note::
+..  note::
 
-   This extension follows `Semantic Versioning <https://semver.org/>`__.
+    This extension follows `Semantic Versioning <https://semver.org/>`__.
 
-.. _preparation:
+..  _preparation:
 
 Preparation
 -----------
 
 Clone the repository first:
 
-.. code-block:: bash
+..  code-block:: bash
 
-   git clone https://github.com/CPS-IT/handlebars.git
-   cd handlebars
+    git clone https://github.com/CPS-IT/handlebars.git
+    cd handlebars
 
 Now install all Composer dependencies:
 
-.. code-block:: bash
+..  code-block:: bash
 
-   composer install
+    composer install
 
-.. _check-code-quality:
+..  _check-code-quality:
 
 Check code quality
 ------------------
 
-.. image:: https://github.com/CPS-IT/handlebars/actions/workflows/cgl.yaml/badge.svg
-   :target: https://github.com/CPS-IT/handlebars/actions/workflows/cgl.yaml
+..  rst-class:: d-inline-block mb-3
 
-.. rst-class:: mt-3
+..  image:: https://github.com/CPS-IT/handlebars/actions/workflows/cgl.yaml/badge.svg
+    :target: https://github.com/CPS-IT/handlebars/actions/workflows/cgl.yaml
 
-.. code-block:: bash
+..  code-block:: bash
 
-   # Run all linters
-   composer lint
+    # Run all linters
+    composer lint
 
-   # Run Composer normalization
-   composer lint:composer
+    # Run Composer normalization
+    composer lint:composer
 
-   # Run PHP linter only
-   composer lint:php
+    # Run PHP linter only
+    composer lint:php
 
-   # Run TypoScript linter only
-   composer lint:typoscript
+    # Run TypoScript linter only
+    composer lint:typoscript
 
-   # Run PHP static code analysis
-   composer sca
+    # Run PHP static code analysis
+    composer sca
 
-.. _run-tests:
+..  _run-tests:
 
 Run tests
 ---------
 
-.. image:: https://github.com/CPS-IT/handlebars/actions/workflows/tests.yaml/badge.svg
-   :target: https://github.com/CPS-IT/handlebars/actions/workflows/tests.yaml
+..  image:: https://github.com/CPS-IT/handlebars/actions/workflows/tests.yaml/badge.svg
+    :target: https://github.com/CPS-IT/handlebars/actions/workflows/tests.yaml
 
-.. image:: https://codecov.io/gh/CPS-IT/handlebars/branch/develop/graph/badge.svg?token=6TDD6TVHQH
-   :target: https://codecov.io/gh/CPS-IT/handlebars
+..  rst-class:: d-inline-block mb-3
 
-.. rst-class:: mt-3
+..  image:: https://codecov.io/gh/CPS-IT/handlebars/branch/develop/graph/badge.svg?token=6TDD6TVHQH
+    :target: https://codecov.io/gh/CPS-IT/handlebars
 
-.. code-block:: bash
+..  code-block:: bash
 
-   # Run tests
-   composer test
+    # Run tests
+    composer test
 
-   # Run tests with code coverage
-   composer test:ci
+    # Run tests with code coverage
+    composer test:ci
 
 The code coverage reports will be stored in :file:`.Build/log/coverage`.
 
-.. _build-documentation:
+..  _build-documentation:
 
 Build documentation
 -------------------
 
-.. code-block:: bash
+..  code-block:: bash
 
-   # Rebuild and open documentation
-   composer docs
+    # Rebuild and open documentation
+    composer docs
 
-   # Build documentation (from cache)
-   composer docs:build
+    # Build documentation (from cache)
+    composer docs:build
 
-   # Open rendered documentation
-   composer docs:open
+    # Open rendered documentation
+    composer docs:open
 
 The built docs will be stored in :file:`.Build/docs`.
 
-.. _pull-request:
+..  _pull-request:
 
 Pull Request
 ------------

--- a/Documentation/Includes.rst.txt
+++ b/Documentation/Includes.rst.txt
@@ -1,17 +1,17 @@
-.. This is 'Includes.rst.txt'. It is included at the very top of each and
-   every ReST source file in THIS documentation project (= manual).
+..  This is 'Includes.rst.txt'. It is included at the very top of each and
+    every ReST source file in THIS documentation project (= manual).
 
-.. role:: aspect (emphasis)
-.. role:: html(code)
-.. role:: js(code)
-.. role:: php(code)
-.. role:: sep (strong)
-.. role:: sql(code)
-.. role:: typoscript(code)
-.. role:: yaml(code)
+..  role:: aspect (emphasis)
+..  role:: html(code)
+..  role:: js(code)
+..  role:: php(code)
+..  role:: sep (strong)
+..  role:: sql(code)
+..  role:: typoscript(code)
+..  role:: yaml(code)
 
-.. role:: ts(typoscript)
-   :class: typoscript
+..  role:: ts(typoscript)
+    :class: typoscript
 
-.. default-role:: code
-.. highlight:: php
+..  default-role:: code
+..  highlight:: php

--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -7,21 +7,21 @@ Handlebars
 ==========
 
 :Version:
-   |release|
+    |release|
 
 :Language:
-   en
+    en
 
 :Author:
-   Elias Häußler, coding. powerful. systems. CPS GmbH
+    Elias Häußler, coding. powerful. systems. CPS GmbH
 
 :Email:
-   e.haeussler@familie-redlich.de
+    e.haeussler@familie-redlich.de
 
 :License:
-   This extension documentation is published under the
-   `CC BY-NC-SA 4.0 <https://creativecommons.org/licenses/by-nc-sa/4.0/>`__ (Creative Commons)
-   license
+    This extension documentation is published under the
+    `CC BY-NC-SA 4.0 <https://creativecommons.org/licenses/by-nc-sa/4.0/>`__ (Creative Commons)
+    license
 
 **TYPO3**
 
@@ -39,24 +39,24 @@ If you find an error or something is missing, please
 `create an issue <https://github.com/CPS-IT/handlebars/issues/new>`_ or click on
 "Edit me on GitHub" on the top right to submit your change request.
 
-.. _contents:
+..  _contents:
 
 Contents
 ========
 
-.. toctree::
-   :maxdepth: 3
+..  toctree::
+    :maxdepth: 3
 
-   Introduction/Index
-   Installation/Index
-   Configuration/Index
-   Usage/Index
-   RenderingConcept/Index
-   Compatibility/Index
-   Contributing/Index
+    Introduction/Index
+    Installation/Index
+    Configuration/Index
+    Usage/Index
+    RenderingConcept/Index
+    Compatibility/Index
+    Contributing/Index
 
-.. toctree::
-   :hidden:
+..  toctree::
+    :hidden:
 
-   Sitemap
-   genindex
+    Sitemap
+    genindex

--- a/Documentation/Installation/Index.rst
+++ b/Documentation/Installation/Index.rst
@@ -1,12 +1,12 @@
-.. include:: /Includes.rst.txt
+..  include:: /Includes.rst.txt
 
-.. _installation:
+..  _installation:
 
 ============
 Installation
 ============
 
-.. _requirements:
+..  _requirements:
 
 Requirements
 ============
@@ -14,44 +14,44 @@ Requirements
 * PHP 7.1 - 8.1
 * TYPO3 10.4 LTS - 11.5 LTS
 
-.. _steps:
+..  _steps:
 
 Installation
 ============
 
 Require the extension via Composer (recommended):
 
-.. code-block:: bash
+..  code-block:: bash
 
-   composer require cpsit/typo3-handlebars
+    composer require cpsit/typo3-handlebars
 
 Or download it from
 `TYPO3 extension repository <https://extensions.typo3.org/extension/handlebars>`__.
 
-.. _define-dependencies:
+..  _define-dependencies:
 
 Define dependencies
 -------------------
 
-.. attention::
+..  attention::
 
-   This is an essential step to ensure service configuration is interpreted
-   correctly.
+    This is an essential step to ensure service configuration is interpreted
+    correctly.
 
 Each extension that depends on EXT:handlebars needs to explicitly define it as
 dependency in the appropriate :file:`ext_emconf.php` file:
 
 ::
 
-   # ext_emconf.php
+    # ext_emconf.php
 
-   $EM_CONF[$_EXTKEY] = [
-       'constraints' => [
-           'depends' => [
-               'handlebars' => '0.7.0-0.7.99',
-           ],
-       ],
-   ];
+    $EM_CONF[$_EXTKEY] = [
+        'constraints' => [
+            'depends' => [
+                'handlebars' => '0.7.0-0.7.99',
+            ],
+        ],
+    ];
 
 Otherwise, template paths are not evaluated in the right order and might get
 overridden.

--- a/Documentation/Introduction/Index.rst
+++ b/Documentation/Introduction/Index.rst
@@ -1,12 +1,12 @@
-.. include:: /Includes.rst.txt
+..  include:: /Includes.rst.txt
 
-.. _introduction:
+..  _introduction:
 
 ============
 Introduction
 ============
 
-.. _what-it-does:
+..  _what-it-does:
 
 What does it do?
 ================
@@ -19,7 +19,7 @@ Handlebars.js are supported by the usage of the third-party library
 Its main use is to seamlessly integrate Handlebars templates into TYPO3 without
 the need to modify these templates again for output in TYPO3.
 
-.. _features:
+..  _features:
 
 Features
 ========
@@ -30,7 +30,7 @@ Features
 * Built on dependency injection for better performance and maintainability
 * Integration with TYPO3's cache framework for compiled templates
 
-.. _support:
+..  _support:
 
 Support
 =======
@@ -40,7 +40,7 @@ There are several ways to get support for this extension:
 * Slack: https://typo3.slack.com/messages/ext-handlebars
 * GitHub: https://github.com/CPS-IT/handlebars/issues
 
-.. _contributors:
+..  _contributors:
 
 Contributors
 ============
@@ -48,7 +48,7 @@ Contributors
 This extension is based on the great work of `Digitas Pixelpark GmbH <https://www.digitaspixelpark.com/>`_.
 It was heavily extended and is now maintained by `coding. powerful. systems. CPS GmbH <https://www.cps-it.de/>`_.
 
-.. _license:
+..  _license:
 
 License
 =======

--- a/Documentation/RenderingConcept/Index.rst
+++ b/Documentation/RenderingConcept/Index.rst
@@ -1,30 +1,30 @@
-.. include:: /Includes.rst.txt
+..  include:: /Includes.rst.txt
 
-.. _rendering-concept:
+..  _rendering-concept:
 
 =================
 Rendering concept
 =================
 
-.. image:: ../Images/RenderingChart.svg
-   :alt: Rendering chart
-   :target: ../_images/RenderingChart.svg
+..  image:: ../Images/RenderingChart.svg
+    :alt: Rendering chart
+    :target: ../_images/RenderingChart.svg
 
 The following components are involved in the rendering process and
 assume different roles in the MVC pattern:
 
-.. contents::
-   :local:
-   :depth: 1
+..  contents::
+    :local:
+    :depth: 1
 
-.. _data-provider:
+..  _data-provider:
 
 `DataProvider` (*Model*)
 ========================
 
-.. rst-class:: horizbuttons-primary-m
+..  rst-class:: horizbuttons-primary-m
 
--  `DataProviderInterface <https://github.com/CPS-IT/handlebars/blob/main/Classes/Data/DataProviderInterface.php>`__
+- `DataProviderInterface <https://github.com/CPS-IT/handlebars/blob/main/Classes/Data/DataProviderInterface.php>`__
 
 `DataProviders` are used to provide relevant data for processing by a
 `DataProcessor`. The data source is irrelevant: data can be provided both
@@ -36,15 +36,15 @@ The data supplied is not necessarily only applicable to a specific template,
 but serves the general usability of all components involved in the rendering
 process of a parent module.
 
-.. _data-processor:
+..  _data-processor:
 
 `DataProcessor` (*Controller*)
 ==============================
 
-.. rst-class:: horizbuttons-primary-m
+..  rst-class:: horizbuttons-primary-m
 
--  `DataProcessorInterface <https://github.com/CPS-IT/handlebars/blob/main/Classes/DataProcessing/DataProcessorInterface.php>`__
--  `AbstractDataProcessor <https://github.com/CPS-IT/handlebars/blob/main/Classes/DataProcessing/AbstractDataProcessor.php>`__
+- `DataProcessorInterface <https://github.com/CPS-IT/handlebars/blob/main/Classes/DataProcessing/DataProcessorInterface.php>`__
+- `AbstractDataProcessor <https://github.com/CPS-IT/handlebars/blob/main/Classes/DataProcessing/AbstractDataProcessor.php>`__
 
 `DataProcessors` are the entry point into the entire rendering process.
 They fetch the data from the `DataProvider`, process it and pass it on to
@@ -54,15 +54,15 @@ This is where the entire processing logic takes place. Thus, `DataProcessors`
 fulfill the part of the *Controller* in the MVC pattern. They are usually
 addressed directly via TypoScript.
 
-.. _presenter:
+..  _presenter:
 
 `Presenter` (*View transition*)
 ===============================
 
-.. rst-class:: horizbuttons-primary-m
+..  rst-class:: horizbuttons-primary-m
 
--  `PresenterInterface <https://github.com/CPS-IT/handlebars/blob/main/Classes/Presenter/PresenterInterface.php>`__
--  `AbstractPresenter <https://github.com/CPS-IT/handlebars/blob/main/Classes/Presenter/AbstractPresenter.php>`__
+- `PresenterInterface <https://github.com/CPS-IT/handlebars/blob/main/Classes/Presenter/PresenterInterface.php>`__
+- `AbstractPresenter <https://github.com/CPS-IT/handlebars/blob/main/Classes/Presenter/AbstractPresenter.php>`__
 
 In `Presenter`, the supplied data is prepared for rendering a specific
 Handlebars template. Dependent templates can also be selected based on
@@ -71,15 +71,15 @@ the supplied data if multiple template variants are possible.
 In the MVC pattern, the `Presenter` takes on a transitional role
 between the `DataProcessor` (*Controller*) and the `Renderer` (*View*).
 
-.. _renderer:
+..  _renderer:
 
 `Renderer` (*View*)
 ===================
 
-.. rst-class:: horizbuttons-primary-m
+..  rst-class:: horizbuttons-primary-m
 
--  `RendererInterface <https://github.com/CPS-IT/handlebars/blob/main/Classes/Renderer/RendererInterface.php>`__
--  `HandlebarsRenderer <https://github.com/CPS-IT/handlebars/blob/main/Classes/Renderer/HandlebarsRenderer.php>`__
+- `RendererInterface <https://github.com/CPS-IT/handlebars/blob/main/Classes/Renderer/RendererInterface.php>`__
+- `HandlebarsRenderer <https://github.com/CPS-IT/handlebars/blob/main/Classes/Renderer/HandlebarsRenderer.php>`__
 
 The template is finally rendered in the `Renderer`. For this purpose,
 the template is compiled and filled with data from the `Presenter`. The
@@ -88,14 +88,14 @@ resulting output is returned and completes the rendering process.
 The `Renderer` is thus responsible for the *View* in the context of the
 MVC pattern. The compiled templates used for this are usually cached.
 
-.. _helper:
+..  _helper:
 
 `Helper` (optional)
 ===================
 
-.. rst-class:: horizbuttons-primary-m
+..  rst-class:: horizbuttons-primary-m
 
--  `HelperInterface <https://github.com/CPS-IT/handlebars/blob/main/Classes/Renderer/Helper/HelperInterface.php>`__
+- `HelperInterface <https://github.com/CPS-IT/handlebars/blob/main/Classes/Renderer/Helper/HelperInterface.php>`__
 
 `Helpers` describe a simple way to bring custom PHP functionality to
 Handlebars templates. They are similar to ViewHelpers used in Fluid
@@ -114,15 +114,15 @@ they are not explicitly involved. However, since they are implicitly
 involved in the output of a template, they most likely take the role
 of the *View*.
 
-.. _template-resolver:
+..  _template-resolver:
 
 `TemplateResolver`
 ==================
 
-.. rst-class:: horizbuttons-primary-m
+..  rst-class:: horizbuttons-primary-m
 
--  `TemplateResolverInterface <https://github.com/CPS-IT/handlebars/blob/main/Classes/Renderer/Template/TemplateResolverInterface.php>`__
--  `HandlebarsTemplateResolver <https://github.com/CPS-IT/handlebars/blob/main/Classes/Renderer/Template/HandlebarsTemplateResolver.php>`__
+- `TemplateResolverInterface <https://github.com/CPS-IT/handlebars/blob/main/Classes/Renderer/Template/TemplateResolverInterface.php>`__
+- `HandlebarsTemplateResolver <https://github.com/CPS-IT/handlebars/blob/main/Classes/Renderer/Template/HandlebarsTemplateResolver.php>`__
 
 Whenever a template is rendered by the `Renderer`, it must first be
 resolved, e.g. by looking it up in all defined template root paths. It

--- a/Documentation/Sitemap.rst
+++ b/Documentation/Sitemap.rst
@@ -1,9 +1,9 @@
 :template: sitemap.html
 
-.. include:: /Includes.rst.txt
+..  include:: /Includes.rst.txt
 
 =======
 Sitemap
 =======
 
-.. The sitemap.html template will insert here the page tree automatically.
+..  The sitemap.html template will insert here the page tree automatically.

--- a/Documentation/Usage/Basic/Index.rst
+++ b/Documentation/Usage/Basic/Index.rst
@@ -1,6 +1,6 @@
-.. include:: /Includes.rst.txt
+..  include:: /Includes.rst.txt
 
-.. _basic-usage:
+..  _basic-usage:
 
 ===========
 Basic usage
@@ -12,268 +12,268 @@ in the frontend using a Handlebars template.
 
 The CType `header` serves as an example.
 
-.. note::
+..  note::
 
-   This example only describes the standard process for creating a new
-   module. Further possibilities are described in the section
-   :ref:`extended-usage`.
+    This example only describes the standard process for creating a new
+    module. Further possibilities are described in the section
+    :ref:`extended-usage`.
 
-.. _example:
+..  _example:
 
 Example
 =======
 
-.. note::
+..  note::
 
-   All examples are written in PHP 7.4.
+    All examples are written in PHP 7.4.
 
-.. rst-class:: bignums-xxl
+..  rst-class:: bignums-xxl
 
-#. Preparations
+#.  Preparations
 
-   Before the actual components are created, some preliminary work is
-   necessary.
+    Before the actual components are created, some preliminary work is
+    necessary.
 
-   .. rst-class:: bignums
+    ..  rst-class:: bignums
 
-   #. Installation
+    #.  Installation
 
-      :ref:`Install <installation>` the extension using Composer.
+        :ref:`Install <installation>` the extension using Composer.
 
-   #. Define dependencies
+    #.  Define dependencies
 
-      Add the extension as dependency to your extension as described
-      :ref:`here <define-dependencies>`.
+        Add the extension as dependency to your extension as described
+        :ref:`here <define-dependencies>`.
 
-   #. `Services.yaml`
+    #.  `Services.yaml`
 
-      Create a basic :file:`Services.yaml` file in your extension. Make sure
-      to read and follow the guidelines described at
-      :ref:`Dependency injection <t3coreapi:dependency-injection>`.
+        Create a basic :file:`Services.yaml` file in your extension. Make sure
+        to read and follow the guidelines described at
+        :ref:`Dependency injection <t3coreapi:dependency-injection>`.
 
-   #. TypoScript configuration
+    #.  TypoScript configuration
 
-      Create a TypoScript configuration file and include it in your site's root
-      template. Make sure to include static TypoScript from
-      EXT:fluid_styled_content.
+        Create a TypoScript configuration file and include it in your site's root
+        template. Make sure to include static TypoScript from
+        EXT:fluid_styled_content.
 
-#. Create a new `DataProcessor`
+#.  Create a new `DataProcessor`
 
-   Each `DataProcessor` must implement :php:`Fr\Typo3Handlebars\DataProcessing\DataProcessorInterface`.
+    Each `DataProcessor` must implement :php:`Fr\Typo3Handlebars\DataProcessing\DataProcessorInterface`.
 
-   There's already a default `DataProcessor` in place that provides some
-   basic logic and is required in case you want to develop components
-   like described on this page. Just extend your `DataProcessor` from
-   :php:`Fr\Typo3Handlebars\DataProcessing\AbstractDataProcessor` and
-   implement the abstract method :php:`render()`:
+    There's already a default `DataProcessor` in place that provides some
+    basic logic and is required in case you want to develop components
+    like described on this page. Just extend your `DataProcessor` from
+    :php:`Fr\Typo3Handlebars\DataProcessing\AbstractDataProcessor` and
+    implement the abstract method :php:`render()`:
 
-   ::
+    ::
 
-      # Classes/DataProcessing/HeaderProcessor.php
+        # Classes/DataProcessing/HeaderProcessor.php
 
-      namespace Vendor\Extension\DataProcessing;
+        namespace Vendor\Extension\DataProcessing;
 
-      use Fr\Typo3Handlebars\DataProcessing\AbstractDataProcessor;
+        use Fr\Typo3Handlebars\DataProcessing\AbstractDataProcessor;
 
-      class HeaderProcessor extends AbstractDataProcessor
-      {
-          protected function render(): string
-          {
-              $data = $this->provider->get($this->cObj->data);
-              return $this->presenter->present($data);
-          }
-      }
+        class HeaderProcessor extends AbstractDataProcessor
+        {
+            protected function render(): string
+            {
+                $data = $this->provider->get($this->cObj->data);
+                return $this->presenter->present($data);
+            }
+        }
 
-   .. attention::
+    ..  attention::
 
-      **Use the correct namespace**
+        **Use the correct namespace**
 
-      It is very important to create the `DataProcessor` with the correct
-      namespace, as all other components will be automatically registered
-      based on it.
+        It is very important to create the `DataProcessor` with the correct
+        namespace, as all other components will be automatically registered
+        based on it.
 
-#. Register `DataProcessor` as service
+#.  Register `DataProcessor` as service
 
-   The `HeaderProcessor` must now be registered in the :file:`Services.yaml`
-   in the next step:
+    The `HeaderProcessor` must now be registered in the :file:`Services.yaml`
+    in the next step:
 
-   .. code-block:: yaml
+    ..  code-block:: yaml
 
-      # Configuration/Services.yaml
+        # Configuration/Services.yaml
 
-      services:
-        Vendor\Extension\DataProcessing\HeaderProcessor:
-          tags: ['handlebars.processor']
+        services:
+          Vendor\Extension\DataProcessing\HeaderProcessor:
+            tags: ['handlebars.processor']
 
-   All related components (`DataProvider`, `Presenter`) are now automatically
-   assigned to this `DataProcessor` and registered accordingly.
+    All related components (`DataProvider`, `Presenter`) are now automatically
+    assigned to this `DataProcessor` and registered accordingly.
 
-   .. tip::
+    ..  tip::
 
-      If all `DataProcessors` share the same configuration, they can also be
-      registered all at once with the following configuration:
+        If all `DataProcessors` share the same configuration, they can also be
+        registered all at once with the following configuration:
 
-      .. code-block:: yaml
+        ..  code-block:: yaml
 
-         # Configuration/Services.yaml
+            # Configuration/Services.yaml
 
-         services:
-           Vendor\Extension\DataProcessing\:
-             resource: '../Classes/DataProcessing/**/*Processor.php'
-             tags: ['handlebars.processor']
+            services:
+              Vendor\Extension\DataProcessing\:
+                resource: '../Classes/DataProcessing/**/*Processor.php'
+                tags: ['handlebars.processor']
 
-#. Create a new `DataProvider`
+#.  Create a new `DataProvider`
 
-   Next, a `DataProvider` must be created that prepares the module's data and makes
-   it available to the `DataProcessor` again. Each `DataProvider` must implement
-   :php:`Fr\Typo3Handlebars\Data\DataProviderInterface`.
+    Next, a `DataProvider` must be created that prepares the module's data and makes
+    it available to the `DataProcessor` again. Each `DataProvider` must implement
+    :php:`Fr\Typo3Handlebars\Data\DataProviderInterface`.
 
-   ::
-
-      # Classes/Data/HeaderProvider.php
-
-      namespace Vendor\Extension\Data;
-
-      use Fr\Typo3Handlebars\Data\DataProviderInterface;
-      use Fr\Typo3Handlebars\Data\Response\ProviderResponseInterface;
-      use Vendor\Extension\Data\Response\HeaderProviderResponse;
-
-      class HeaderProvider implements DataProviderInterface
-      {
-          public function get(array $data): ProviderResponseInterface
-          {
-              return (new HeaderProviderResponse($data['header']))
-                  ->setHeaderLayout((int)$data['header_layout'])
-                  ->setHeaderLink($data['header_link'])
-                  ->setSubheader($data['subheader']);
-          }
-      }
+    ::
+
+        # Classes/Data/HeaderProvider.php
+
+        namespace Vendor\Extension\Data;
+
+        use Fr\Typo3Handlebars\Data\DataProviderInterface;
+        use Fr\Typo3Handlebars\Data\Response\ProviderResponseInterface;
+        use Vendor\Extension\Data\Response\HeaderProviderResponse;
+
+        class HeaderProvider implements DataProviderInterface
+        {
+            public function get(array $data): ProviderResponseInterface
+            {
+                return (new HeaderProviderResponse($data['header']))
+                    ->setHeaderLayout((int)$data['header_layout'])
+                    ->setHeaderLink($data['header_link'])
+                    ->setSubheader($data['subheader']);
+            }
+        }
 
-   As you can see, the `DataProvider` returns an instance of a so-called
-   `ProviderResponse` object. This holds the prepared data for higher-level transfer
-   within the rendering process. Create it in the associated namespace:
+    As you can see, the `DataProvider` returns an instance of a so-called
+    `ProviderResponse` object. This holds the prepared data for higher-level transfer
+    within the rendering process. Create it in the associated namespace:
 
-   ::
+    ::
 
-      # Classes/Data/Response/HeaderProviderResponse.php
+        # Classes/Data/Response/HeaderProviderResponse.php
 
-      namespace Vendor\Extension\Data\Response;
+        namespace Vendor\Extension\Data\Response;
 
-      use Fr\Typo3Handlebars\Data\Response\ProviderResponseInterface;
+        use Fr\Typo3Handlebars\Data\Response\ProviderResponseInterface;
 
-      class HeaderProviderResponse implements ProviderResponseInterface
-      {
-          public const LAYOUT_DEFAULT = 0;
+        class HeaderProviderResponse implements ProviderResponseInterface
+        {
+            public const LAYOUT_DEFAULT = 0;
 
-          private string $header;
-          private int $headerLayout = self::LAYOUT_DEFAULT;
-          private string $headerLink = '';
-          private string $subheader = '';
+            private string $header;
+            private int $headerLayout = self::LAYOUT_DEFAULT;
+            private string $headerLink = '';
+            private string $subheader = '';
 
-          public function __construct(string $header)
-          {
-              $this->header = $header;
-              $this->validate();
-          }
+            public function __construct(string $header)
+            {
+                $this->header = $header;
+                $this->validate();
+            }
 
-          // Getters and setters...
+            // Getters and setters...
 
-          public function toArray(): array
-          {
-              return [
-                  'header' => $this->header,
-                  'headerLayout' => $this->headerLayout,
-                  'headerLink' => $this->headerLink,
-                  'subheader' => $this->subheader,
-              ];
-          }
+            public function toArray(): array
+            {
+                return [
+                    'header' => $this->header,
+                    'headerLayout' => $this->headerLayout,
+                    'headerLink' => $this->headerLink,
+                    'subheader' => $this->subheader,
+                ];
+            }
 
-          private function validate(): void
-          {
-              if ('' === trim($this->header)) {
-                  throw new \InvalidArgumentException('Header must not be empty.', 1626108393);
-              }
-          }
-      }
+            private function validate(): void
+            {
+                if ('' === trim($this->header)) {
+                    throw new \InvalidArgumentException('Header must not be empty.', 1626108393);
+                }
+            }
+        }
 
-#. Create a new `Presenter`
+#.  Create a new `Presenter`
 
-   To complete the rendering process, a new `Presenter` called `HeaderPresenter`
-   must be created. It must implement the :php:`Fr\Typo3Handlebars\Presenter\PresenterInterface`;
-   furthermore, an :php:`Fr\Typo3Handlebars\Presenter\AbstractPresenter` is already
-   available with the default `Renderer` already specified as a dependency.
+    To complete the rendering process, a new `Presenter` called `HeaderPresenter`
+    must be created. It must implement the :php:`Fr\Typo3Handlebars\Presenter\PresenterInterface`;
+    furthermore, an :php:`Fr\Typo3Handlebars\Presenter\AbstractPresenter` is already
+    available with the default `Renderer` already specified as a dependency.
 
-   ::
+    ::
 
-      # Classes/Presenter/HeaderPresenter.php
+        # Classes/Presenter/HeaderPresenter.php
 
-      namespace Vendor\Extension\Presenter;
+        namespace Vendor\Extension\Presenter;
 
-      use Fr\Typo3Handlebars\Data\Response\ProviderResponseInterface;
-      use Fr\Typo3Handlebars\Exception\UnableToPresentException;
-      use Fr\Typo3Handlebars\Presenter\AbstractPresenter;
+        use Fr\Typo3Handlebars\Data\Response\ProviderResponseInterface;
+        use Fr\Typo3Handlebars\Exception\UnableToPresentException;
+        use Fr\Typo3Handlebars\Presenter\AbstractPresenter;
 
-      class HeaderPresenter extends AbstractPresenter
-      {
-          public function present(ProviderResponseInterface $data): string
-          {
-              if (!($data instanceof HeaderProviderResponse)) {
-                  throw new UnableToPresentException(
-                      'Received unexpected response from provider.',
-                      1613552315
-                  );
-              }
+        class HeaderPresenter extends AbstractPresenter
+        {
+            public function present(ProviderResponseInterface $data): string
+            {
+                if (!($data instanceof HeaderProviderResponse)) {
+                    throw new UnableToPresentException(
+                        'Received unexpected response from provider.',
+                        1613552315
+                    );
+                }
 
-              // Use data from ProviderResponse or implement custom logic
-              $renderData = $data->toArray();
+                // Use data from ProviderResponse or implement custom logic
+                $renderData = $data->toArray();
 
-              return $this->renderer->render(
-                  'Extensions/FluidStyledContent/Header',
-                  $renderData
-              );
-          }
-      }
+                return $this->renderer->render(
+                    'Extensions/FluidStyledContent/Header',
+                    $renderData
+                );
+            }
+        }
 
-#. Set up TypoScript configuration
+#.  Set up TypoScript configuration
 
-   Finally, you have to configure via TypoScript that instead of the default Fluid
-   rendering the special Handlebars rendering should be executed for all content
-   elements of the CType `header`.
+    Finally, you have to configure via TypoScript that instead of the default Fluid
+    rendering the special Handlebars rendering should be executed for all content
+    elements of the CType `header`.
 
-   For this purpose, each `DataProcessor` provides a method
-   :php:`process(string $content, array $configuration)` as entry point.
+    For this purpose, each `DataProcessor` provides a method
+    :php:`process(string $content, array $configuration)` as entry point.
 
-   .. code-block:: typoscript
+    ..  code-block:: typoscript
 
-      # Configuration/TypoScript/setup.typoscript
+        # Configuration/TypoScript/setup.typoscript
 
-      tt_content.header = USER
-      tt_content.header.userFunc = Vendor\Extension\DataProcessing\HeaderProcessor->process
+        tt_content.header = USER
+        tt_content.header.userFunc = Vendor\Extension\DataProcessing\HeaderProcessor->process
 
-#. Optional: Create custom `Helpers`
+#.  Optional: Create custom `Helpers`
 
-   If your templates use custom `Helpers`, you will need to create them
-   additionally. Read :ref:`create-a-custom-helper` to learn what options are
-   available for creating your own `Helpers`.
+    If your templates use custom `Helpers`, you will need to create them
+    additionally. Read :ref:`create-a-custom-helper` to learn what options are
+    available for creating your own `Helpers`.
 
-#. Flush caches
+#.  Flush caches
 
-   Changes were made to the service configuration and also the rendering was
-   overwritten using TypoScript. Therefore, it is now necessary to ensure that
-   the **caches are flushed and the service container is reconfigured**.
+    Changes were made to the service configuration and also the rendering was
+    overwritten using TypoScript. Therefore, it is now necessary to ensure that
+    the **caches are flushed and the service container is reconfigured**.
 
-.. _basic-usage-sources:
+..  _basic-usage-sources:
 
 Sources
 =======
 
-.. seealso::
+..  seealso::
 
-   View the sources on GitHub:
+    View the sources on GitHub:
 
-   -  `DataProcessorInterface <https://github.com/CPS-IT/handlebars/blob/main/Classes/DataProcessing/DataProcessorInterface.php>`__
-   -  `AbstractDataProcessor <https://github.com/CPS-IT/handlebars/blob/main/Classes/DataProcessing/AbstractDataProcessor.php>`__
-   -  `DataProviderInterface <https://github.com/CPS-IT/handlebars/blob/main/Classes/Data/DataProviderInterface.php>`__
-   -  `ProviderResponseInterface <https://github.com/CPS-IT/handlebars/blob/main/Classes/Data/Response/ProviderResponseInterface.php>`__
-   -  `PresenterInterface <https://github.com/CPS-IT/handlebars/blob/main/Classes/Presenter/PresenterInterface.php>`__
-   -  `AbstractPresenter <https://github.com/CPS-IT/handlebars/blob/main/Classes/Presenter/AbstractPresenter.php>`__
+    - `DataProcessorInterface <https://github.com/CPS-IT/handlebars/blob/main/Classes/DataProcessing/DataProcessorInterface.php>`__
+    - `AbstractDataProcessor <https://github.com/CPS-IT/handlebars/blob/main/Classes/DataProcessing/AbstractDataProcessor.php>`__
+    - `DataProviderInterface <https://github.com/CPS-IT/handlebars/blob/main/Classes/Data/DataProviderInterface.php>`__
+    - `ProviderResponseInterface <https://github.com/CPS-IT/handlebars/blob/main/Classes/Data/Response/ProviderResponseInterface.php>`__
+    - `PresenterInterface <https://github.com/CPS-IT/handlebars/blob/main/Classes/Presenter/PresenterInterface.php>`__
+    - `AbstractPresenter <https://github.com/CPS-IT/handlebars/blob/main/Classes/Presenter/AbstractPresenter.php>`__

--- a/Documentation/Usage/Extended/CreateACustomHelper/Index.rst
+++ b/Documentation/Usage/Extended/CreateACustomHelper/Index.rst
@@ -1,6 +1,6 @@
-.. include:: /Includes.rst.txt
+..  include:: /Includes.rst.txt
 
-.. _create-a-custom-helper:
+..  _create-a-custom-helper:
 
 ========================
 Create a custom `Helper`
@@ -10,12 +10,12 @@ Any `Helper` implemented in the frontend via JavaScript and used in Handlebars
 templates must also be replicated in PHP. For this purpose, the extension
 provides an interface :php:`Fr\Typo3Handlebars\Renderer\Helper\HelperInterface`.
 
-.. note::
+..  note::
 
-   In the following examples, a `Helper` is created with the identifier `greet`.
-   The associated class name is :php:`Vendor\Extension\Renderer\Helper\GreetHelper`.
+    In the following examples, a `Helper` is created with the identifier `greet`.
+    The associated class name is :php:`Vendor\Extension\Renderer\Helper\GreetHelper`.
 
-.. _implementation-options:
+..  _implementation-options:
 
 Implementation options
 ======================
@@ -29,7 +29,7 @@ Basically every registered `Helper` must be
 that both globally defined functions and invokable classes as well as class
 methods are possible. See what options are available in the following examples.
 
-.. _global-function:
+..  _global-function:
 
 Global function
 ---------------
@@ -39,12 +39,12 @@ is recognized by the registered PHP autoloader.
 
 ::
 
-   function greet(array $context): string
-   {
-       return sprintf('Hello, %s!', $context['hash']['name']);
-   }
+    function greet(array $context): string
+    {
+        return sprintf('Hello, %s!', $context['hash']['name']);
+    }
 
-.. _invokable-class:
+..  _invokable-class:
 
 Invokable class
 ---------------
@@ -54,21 +54,21 @@ that they implement the method :php:`__invoke()`.
 
 ::
 
-   # Classes/Renderer/Helper/GreetHelper.php
+    # Classes/Renderer/Helper/GreetHelper.php
 
-   namespace Vendor\Extension\Renderer\Helper;
+    namespace Vendor\Extension\Renderer\Helper;
 
-   use Fr\Typo3Handlebars\Renderer\Helper\HelperInterface;
+    use Fr\Typo3Handlebars\Renderer\Helper\HelperInterface;
 
-   class GreetHelper implements HelperInterface
-   {
-       public function __invoke(array $context): string
-       {
-           return sprintf('Hello, %s!', $context['hash']['name']);
-       }
-   }
+    class GreetHelper implements HelperInterface
+    {
+        public function __invoke(array $context): string
+        {
+            return sprintf('Hello, %s!', $context['hash']['name']);
+        }
+    }
 
-.. _class-method:
+..  _class-method:
 
 Class method (recommended)
 --------------------------
@@ -80,36 +80,36 @@ takes place :ref:`via the service container <automatic-registration>`.
 
 ::
 
-   # Classes/Renderer/Helper/GreetHelper.php
+    # Classes/Renderer/Helper/GreetHelper.php
 
-   namespace Vendor\Extension\Renderer\Helper;
+    namespace Vendor\Extension\Renderer\Helper;
 
-   use Fr\Typo3Handlebars\Renderer\Helper\HelperInterface;
-   use Vendor\Extension\Domain\Repository\PersonRepository;
+    use Fr\Typo3Handlebars\Renderer\Helper\HelperInterface;
+    use Vendor\Extension\Domain\Repository\PersonRepository;
 
-   class GreetHelper implements HelperInterface
-   {
-       private PersonRepository $repository;
+    class GreetHelper implements HelperInterface
+    {
+        private PersonRepository $repository;
 
-       public function __construct(PersonRepository $repository)
-       {
-           $this->repository = $repository;
-       }
+        public function __construct(PersonRepository $repository)
+        {
+            $this->repository = $repository;
+        }
 
-       public function greetById(array $context): string
-       {
-           $name = (int)$this->getNameById($context['hash']['userId']);
+        public function greetById(array $context): string
+        {
+            $name = (int)$this->getNameById($context['hash']['userId']);
 
-           return sprintf('Hello, %s!', $name);
-       }
+            return sprintf('Hello, %s!', $name);
+        }
 
-       private function getNameById(int $userId): string
-       {
-           return $this->repository->findByUid($userId)->getName();
-       }
-   }
+        private function getNameById(int $userId): string
+        {
+            return $this->repository->findByUid($userId)->getName();
+        }
+    }
 
-.. _registration:
+..  _registration:
 
 Registration
 ============
@@ -117,7 +117,7 @@ Registration
 `Helpers` can be registered either via configuration in the :file:`Services.yaml`
 file or directly via the `Renderer` (if the default `Renderer` is used).
 
-.. _automatic-registration:
+..  _automatic-registration:
 
 Automatic registration via the service container (recommended)
 --------------------------------------------------------------
@@ -126,48 +126,48 @@ The recommended way to register `Helpers` is to use the global service container
 This ensures that the `Helpers` are always available in the `Renderer`. To achieve
 this, add the following lines to your :file:`Services.yaml` file:
 
-.. code-block:: yaml
+..  code-block:: yaml
 
-   # Configuration/Services.yaml
+    # Configuration/Services.yaml
 
-   services:
-     Vendor\Extension\Renderer\Helper\GreetHelper:
-       tags:
-         - name: handlebars.helper
-           identifier: 'greet'
-           method: 'greetById'
+    services:
+      Vendor\Extension\Renderer\Helper\GreetHelper:
+        tags:
+          - name: handlebars.helper
+            identifier: 'greet'
+            method: 'greetById'
 
-.. warning::
+..  warning::
 
-   **Only for implementation as class method**
+    **Only for implementation as class method**
 
-   Note that registration using a tag is available only for the implementation as
-   :ref:`class-method`. For all other implementations, a direct method call must
-   currently still be registered:
+    Note that registration using a tag is available only for the implementation as
+    :ref:`class-method`. For all other implementations, a direct method call must
+    currently still be registered:
 
-   .. code-block:: yaml
+    ..  code-block:: yaml
 
-      # Configuration/Services.yaml
+        # Configuration/Services.yaml
 
-      services:
-        handlebars.renderer_extended:
-          parent: handlebars.renderer
-          calls:
-            # Global function
-            - registerHelper: ['greet', 'greet']
-            # or invokable class
-            - registerHelper: ['greet', '@Vendor\Extension\Renderer\Helper\GreetHelper']
+        services:
+          handlebars.renderer_extended:
+            parent: handlebars.renderer
+            calls:
+              # Global function
+              - registerHelper: ['greet', 'greet']
+              # or invokable class
+              - registerHelper: ['greet', '@Vendor\Extension\Renderer\Helper\GreetHelper']
 
-        Fr\Typo3Handlebars\Renderer\RendererInterface:
-          alias: 'handlebars.renderer_extended'
+          Fr\Typo3Handlebars\Renderer\RendererInterface:
+            alias: 'handlebars.renderer_extended'
 
 The `identifier` configuration specifies how the `Helper` should be named and
 referenced. It will then be used in Handlebars templates when calling the
 registered `Helper`. An example template could look like this:
 
-.. code-block:: handlebars
+..  code-block:: handlebars
 
-   {{ greet id=1 }}
+    {{ greet id=1 }}
 
 It will result in: `Hello, Bob`!
 
@@ -176,7 +176,7 @@ the configured class name. The above example leads to the registration of a
 new `Helper` named `greet` which provides a callback
 :php:`Vendor\Extension\Renderer\Helper\GreetHelper::greetById`.
 
-.. _manual-registration:
+..  _manual-registration:
 
 Manual registration
 -------------------
@@ -188,19 +188,19 @@ manually at any time. For this purpose it is necessary to initialize the
 
 ::
 
-   $renderer->registerHelper(
-       'greet',
-       \Vendor\Extension\Renderer\Helper\GreetHelper::class . '::greetById'
-   );
+    $renderer->registerHelper(
+        'greet',
+        \Vendor\Extension\Renderer\Helper\GreetHelper::class . '::greetById'
+    );
 
-.. _create-a-custom-helper-sources:
+..  _create-a-custom-helper-sources:
 
 Sources
 =======
 
-.. seealso::
+..  seealso::
 
-   View the sources on GitHub:
+    View the sources on GitHub:
 
-   -  `HelperInterface <https://github.com/CPS-IT/handlebars/blob/main/Classes/Renderer/Helper/HelperInterface.php>`__
-   -  `HandlebarsHelperPass <https://github.com/CPS-IT/handlebars/blob/main/Classes/DependencyInjection/HandlebarsHelperPass.php>`__
+    - `HelperInterface <https://github.com/CPS-IT/handlebars/blob/main/Classes/Renderer/Helper/HelperInterface.php>`__
+    - `HandlebarsHelperPass <https://github.com/CPS-IT/handlebars/blob/main/Classes/DependencyInjection/HandlebarsHelperPass.php>`__

--- a/Documentation/Usage/Extended/CustomRenderingComponents/Index.rst
+++ b/Documentation/Usage/Extended/CustomRenderingComponents/Index.rst
@@ -1,6 +1,6 @@
-.. include:: /Includes.rst.txt
+..  include:: /Includes.rst.txt
 
-.. _custom-rendering-components:
+..  _custom-rendering-components:
 
 ===========================
 Custom rendering components
@@ -10,7 +10,7 @@ All components are described using interfaces. This makes it easy to
 exchange individual components. The following illustrates how such a
 use case can look.
 
-.. _custom-renderer:
+..  _custom-renderer:
 
 Custom `Renderer`
 =================
@@ -20,13 +20,13 @@ describes a `Renderer`. A distinction must be made as to whether the
 custom `Renderer` is to be used for all components or only for individual
 variants.
 
-.. important::
+..  important::
 
-   If you want your custom `Renderer` to be autoconfigured with all globally
-   registered `Helpers`, make sure to tag it with `handlebars.renderer` and
-   implement the interface :php:`Fr\Typo3Handlebars\Renderer\HelperAwareInterface`.
+    If you want your custom `Renderer` to be autoconfigured with all globally
+    registered `Helpers`, make sure to tag it with `handlebars.renderer` and
+    implement the interface :php:`Fr\Typo3Handlebars\Renderer\HelperAwareInterface`.
 
-.. _global-replacement:
+..  _global-replacement:
 
 Global replacement
 ------------------
@@ -35,24 +35,24 @@ If the custom `Renderer` is to be used equally for all components, it can
 simply be registered as a global replacement for the default `Renderer` in
 the :file:`Services.yaml` file.
 
-.. code-block:: yaml
+..  code-block:: yaml
 
-   # Configuration/Services.yaml
+    # Configuration/Services.yaml
 
-   services:
-     Fr\Typo3Handlebars\Renderer\RendererInterface:
-       alias: 'Vendor\Extension\Renderer\AlternativeRenderer'
+    services:
+      Fr\Typo3Handlebars\Renderer\RendererInterface:
+        alias: 'Vendor\Extension\Renderer\AlternativeRenderer'
 
-.. warning::
+..  warning::
 
-   **Provide necessary dependencies**
+    **Provide necessary dependencies**
 
-   Note that if you use your own `Renderer`, you are responsible for providing
-   it with the necessary dependencies. These include the cache, `TemplateResolver`,
-   and the default data (if needed). This is already configured with the default
-   `Renderer`.
+    Note that if you use your own `Renderer`, you are responsible for providing
+    it with the necessary dependencies. These include the cache, `TemplateResolver`,
+    and the default data (if needed). This is already configured with the default
+    `Renderer`.
 
-.. _single-replacement:
+..  _single-replacement:
 
 Single replacement
 ------------------
@@ -60,24 +60,24 @@ Single replacement
 A custom `Renderer` can also be used only for specific modules. In this case,
 it replaces the default `Renderer` for the concrete `Presenters`.
 
-.. warning::
+..  warning::
 
-   **Use of the** `AbstractPresenter` **required**
+    **Use of the** `AbstractPresenter` **required**
 
-   The following example is only applicable to `Presenters` that extend the
-   `AbstractPresenter`, since it holds the required dependency in its constructor.
-   This is not part of the `PresenterInterface`.
+    The following example is only applicable to `Presenters` that extend the
+    `AbstractPresenter`, since it holds the required dependency in its constructor.
+    This is not part of the `PresenterInterface`.
 
-.. code-block:: yaml
+..  code-block:: yaml
 
-   # Configuration/Services.yaml
+    # Configuration/Services.yaml
 
-   services:
-     Vendor\Extension\Presenter\MyCustomPresenter:
-       arguments:
-         $renderer: ['@Vendor\Extension\Renderer\AlternativeRenderer']
+    services:
+      Vendor\Extension\Presenter\MyCustomPresenter:
+        arguments:
+          $renderer: ['@Vendor\Extension\Renderer\AlternativeRenderer']
 
-.. _custom-template-resolver:
+..  _custom-template-resolver:
 
 Custom `TemplateResolver`
 =========================
@@ -92,55 +92,55 @@ interface:
 
 ::
 
-   # Classes/Renderer/Template/AlternativeTemplateResolver.php
+    # Classes/Renderer/Template/AlternativeTemplateResolver.php
 
-   namespace Vendor\Extension\Renderer\Template;
+    namespace Vendor\Extension\Renderer\Template;
 
-   use Fr\Typo3Handlebars\Renderer\Template\TemplateResolverInterface;
+    use Fr\Typo3Handlebars\Renderer\Template\TemplateResolverInterface;
 
-   class AlternativeTemplateResolver implements TemplateResolverInterface
-   {
-       /**
-        * @var string[]
-        */
-       private array $supportedFileExtensions = ['hbs', 'hbs.html'];
+    class AlternativeTemplateResolver implements TemplateResolverInterface
+    {
+        /**
+         * @var list<string>
+         */
+        private array $supportedFileExtensions = ['hbs', 'hbs.html'];
 
-       public function getSupportedFileExtensions(): array
-       {
-           return $this->supportedFileExtensions;
-       }
+        public function getSupportedFileExtensions(): array
+        {
+            return $this->supportedFileExtensions;
+        }
 
-       public function supports(string $fileExtension): bool
-       {
-           return in_array(strtolower($fileExtension), $this->supportedFileExtensions, true);
-       }
+        public function supports(string $fileExtension): bool
+        {
+            return in_array(strtolower($fileExtension), $this->supportedFileExtensions, true);
+        }
 
-       public function resolveTemplatePath(string $templatePath): string
-       {
-           // ...
-       }
-   }
+        public function resolveTemplatePath(string $templatePath): string
+        {
+            // ...
+        }
+    }
 
 This is then used in the :file:`Services.yaml` file instead of the standard
 `TemplateResolver`:
 
-.. code-block:: yaml
+..  code-block:: yaml
 
-   # Configuration/Services.yaml
+    # Configuration/Services.yaml
 
-   services:
-     Fr\Typo3Handlebars\Renderer\Template\TemplateResolverInterface:
-       alias: 'Vendor\Extension\Renderer\Template\AlternativeTemplateResolver'
+    services:
+      Fr\Typo3Handlebars\Renderer\Template\TemplateResolverInterface:
+        alias: 'Vendor\Extension\Renderer\Template\AlternativeTemplateResolver'
 
-.. _custom-rendering-components-sources:
+..  _custom-rendering-components-sources:
 
 Sources
 =======
 
-.. seealso::
+..  seealso::
 
-   View the sources on GitHub:
+    View the sources on GitHub:
 
-   -  `RendererInterface <https://github.com/CPS-IT/handlebars/blob/main/Classes/Renderer/RendererInterface.php>`__
-   -  `HelperAwareInterface <https://github.com/CPS-IT/handlebars/blob/main/Classes/Renderer/HelperAwareInterface.php>`__
-   -  `TemplateResolverInterface <https://github.com/CPS-IT/handlebars/blob/main/Classes/Renderer/Template/TemplateResolverInterface.php>`__
+    - `RendererInterface <https://github.com/CPS-IT/handlebars/blob/main/Classes/Renderer/RendererInterface.php>`__
+    - `HelperAwareInterface <https://github.com/CPS-IT/handlebars/blob/main/Classes/Renderer/HelperAwareInterface.php>`__
+    - `TemplateResolverInterface <https://github.com/CPS-IT/handlebars/blob/main/Classes/Renderer/Template/TemplateResolverInterface.php>`__

--- a/Documentation/Usage/Extended/Events/Index.rst
+++ b/Documentation/Usage/Extended/Events/Index.rst
@@ -1,20 +1,20 @@
-.. include:: /Includes.rst.txt
+..  include:: /Includes.rst.txt
 
-.. _events:
+..  _events:
 
 ======
 Events
 ======
 
-.. versionadded:: 0.7.0
+..  versionadded:: 0.7.0
 
-   `Feature: #10 - Introduce BeforeRenderingEvent and AfterRenderingEvent <https://github.com/CPS-IT/handlebars/pull/10>`__
+    `Feature: #10 - Introduce BeforeRenderingEvent and AfterRenderingEvent <https://github.com/CPS-IT/handlebars/pull/10>`__
 
 There are several events available that allow to influence the rendering.
 Event listeners must be registered via the service configuration. More
 information can be found in the :ref:`official TYPO3 documentation <t3coreapi:EventDispatcherRegistration>`.
 
-.. _before-rendering-event:
+..  _before-rendering-event:
 
 BeforeRenderingEvent
 ====================
@@ -27,25 +27,25 @@ Example:
 
 ::
 
-   # Classes/EventListener/BeforeRenderingListener.php
+    # Classes/EventListener/BeforeRenderingListener.php
 
-   namespace Vendor\Extension\EventListener;
+    namespace Vendor\Extension\EventListener;
 
-   use Fr\Typo3Handlebars\Event\BeforeRenderingEvent;
+    use Fr\Typo3Handlebars\Event\BeforeRenderingEvent;
 
-   class BeforeRenderingListener
-   {
-       public function modifyRenderData(BeforeRenderingEvent $event): void
-       {
-           $data = $event->getData();
+    class BeforeRenderingListener
+    {
+        public function modifyRenderData(BeforeRenderingEvent $event): void
+        {
+            $data = $event->getData();
 
-           // Do anything...
+            // Do anything...
 
-           $event->setData($data);
-       }
-   }
+            $event->setData($data);
+        }
+    }
 
-.. _after-rendering-event:
+..  _after-rendering-event:
 
 AfterRenderingEvent
 ===================
@@ -58,32 +58,32 @@ Example:
 
 ::
 
-   # Classes/EventListener/AfterRenderingListener.php
+    # Classes/EventListener/AfterRenderingListener.php
 
-   namespace Vendor\Extension\EventListener;
+    namespace Vendor\Extension\EventListener;
 
-   use Fr\Typo3Handlebars\Event\AfterRenderingEvent;
+    use Fr\Typo3Handlebars\Event\AfterRenderingEvent;
 
-   class AfterRenderingListener
-   {
-       public function modifyRenderedContent(AfterRenderingEvent $event): void
-       {
-           $content = $event->getContent();
+    class AfterRenderingListener
+    {
+        public function modifyRenderedContent(AfterRenderingEvent $event): void
+        {
+            $content = $event->getContent();
 
-           // Do anything...
+            // Do anything...
 
-           $event->setContent($content);
-       }
-   }
+            $event->setContent($content);
+        }
+    }
 
-.. _events-sources:
+..  _events-sources:
 
 Sources
 =======
 
-.. seealso::
+..  seealso::
 
-   View the sources on GitHub:
+    View the sources on GitHub:
 
-   -  `BeforeRenderingEvent <https://github.com/CPS-IT/handlebars/blob/main/Classes/Event/BeforeRenderingEvent.php>`__
-   -  `AfterRenderingEvent <https://github.com/CPS-IT/handlebars/blob/main/Classes/Event/AfterRenderingEvent.php>`__
+    - `BeforeRenderingEvent <https://github.com/CPS-IT/handlebars/blob/main/Classes/Event/BeforeRenderingEvent.php>`__
+    - `AfterRenderingEvent <https://github.com/CPS-IT/handlebars/blob/main/Classes/Event/AfterRenderingEvent.php>`__

--- a/Documentation/Usage/Extended/Index.rst
+++ b/Documentation/Usage/Extended/Index.rst
@@ -1,27 +1,27 @@
-.. include:: /Includes.rst.txt
+..  include:: /Includes.rst.txt
 
-.. _extended-usage:
+..  _extended-usage:
 
 ==============
 Extended usage
 ==============
 
-.. important::
+..  important::
 
-   Take a look at the chapter :ref:`basic-usage` to get an insight into
-   the basic applicability of the individual components. This chapter only
-   covers advanced use cases, which require a basic understanding of all
-   components.
+    Take a look at the chapter :ref:`basic-usage` to get an insight into
+    the basic applicability of the individual components. This chapter only
+    covers advanced use cases, which require a basic understanding of all
+    components.
 
 Several advanced use cases are explained on the following pages. These are
 primarily aimed at specifically extending the standard components.
 
-.. toctree::
-   :maxdepth: 1
+..  toctree::
+    :maxdepth: 1
 
-   SimpleProcessor/Index
-   UsingTheContentObjectRenderer/Index
-   SharedComponents/Index
-   CustomRenderingComponents/Index
-   CreateACustomHelper/Index
-   Events/Index
+    SimpleProcessor/Index
+    UsingTheContentObjectRenderer/Index
+    SharedComponents/Index
+    CustomRenderingComponents/Index
+    CreateACustomHelper/Index
+    Events/Index

--- a/Documentation/Usage/Extended/SharedComponents/Index.rst
+++ b/Documentation/Usage/Extended/SharedComponents/Index.rst
@@ -1,6 +1,6 @@
-.. include:: /Includes.rst.txt
+..  include:: /Includes.rst.txt
 
-.. _shared-components:
+..  _shared-components:
 
 =================
 Shared components
@@ -16,15 +16,15 @@ To be able to cover this special case, it is possible to specify
 a concrete `DataProvider` or `Presenter` for individual `DataProcessors`
 in the :file:`Services.yaml` file.
 
-.. warning::
+..  warning::
 
-   **Use of the** `AbstractDataProcessor` **required**
+    **Use of the** `AbstractDataProcessor` **required**
 
-   The following examples are only applicable to `DataProcessors` that
-   extend the `AbstractDataProcessor`, since it provides the necessary
-   methods. These are not part of the `DataProcessorInterface`.
+    The following examples are only applicable to `DataProcessors` that
+    extend the `AbstractDataProcessor`, since it provides the necessary
+    methods. These are not part of the `DataProcessorInterface`.
 
-.. _example-1-shared-presenter:
+..  _example-1-shared-presenter:
 
 Example 1: Shared `Presenter`
 =============================
@@ -37,24 +37,24 @@ In the :file:`Services.yaml` file, we register both `DataProcessors`, but
 specify a concrete method call :php:`setPresenter()`. This is normally
 called automatically if it is not set manually.
 
-.. code-block:: yaml
+..  code-block:: yaml
 
-   # Configuration/Services.yaml
+    # Configuration/Services.yaml
 
-   services:
-     Vendor\Extension\DataProcessing\HighlightBoxProcessor:
-       tags: ['handlebars.processor']
-       calls:
-         - setPresenter: ['@Vendor\Extension\Presenter\HighlightPresenter']
-     Vendor\Extension\DataProcessing\HighlightTextProcessor:
-       tags: ['handlebars.processor']
-       calls:
-         - setPresenter: ['@Vendor\Extension\Presenter\HighlightPresenter']
+    services:
+      Vendor\Extension\DataProcessing\HighlightBoxProcessor:
+        tags: ['handlebars.processor']
+        calls:
+          - setPresenter: ['@Vendor\Extension\Presenter\HighlightPresenter']
+      Vendor\Extension\DataProcessing\HighlightTextProcessor:
+        tags: ['handlebars.processor']
+        calls:
+          - setPresenter: ['@Vendor\Extension\Presenter\HighlightPresenter']
 
 Both `DataProcessors` are now injected with the same `Presenter`, while all
 other components continue to act independently.
 
-.. _example-2-shared-data-provider:
+..  _example-2-shared-data-provider:
 
 Example 2: Shared `DataProvider`
 ================================
@@ -62,29 +62,29 @@ Example 2: Shared `DataProvider`
 The same procedure can be used if a common `DataProvider` is to be used instead
 of a common `Presenter`. In this case the method call must be :php:`setProvider()`:
 
-.. code-block:: yaml
+..  code-block:: yaml
 
-   # Configuration/Services.yaml
+    # Configuration/Services.yaml
 
-   services:
-     Vendor\Extension\DataProcessing\HighlightBoxProcessor:
-       tags: ['handlebars.processor']
-       calls:
-         - setProvider: ['@Vendor\Extension\Data\HighlightProvider']
-     Vendor\Extension\DataProcessing\HighlightTextProcessor:
-       tags: ['handlebars.processor']
-       calls:
-         - setProvider: ['@Vendor\Extension\Data\HighlightProvider']
+    services:
+      Vendor\Extension\DataProcessing\HighlightBoxProcessor:
+        tags: ['handlebars.processor']
+        calls:
+          - setProvider: ['@Vendor\Extension\Data\HighlightProvider']
+      Vendor\Extension\DataProcessing\HighlightTextProcessor:
+        tags: ['handlebars.processor']
+        calls:
+          - setProvider: ['@Vendor\Extension\Data\HighlightProvider']
 
-.. _shared-components-sources:
+..  _shared-components-sources:
 
 Sources
 =======
 
-.. seealso::
+..  seealso::
 
-   View the sources on GitHub:
+    View the sources on GitHub:
 
-   -  `AbstractDataProcessor <https://github.com/CPS-IT/handlebars/blob/main/Classes/DataProcessing/AbstractDataProcessor.php>`__
-   -  `DataProcessorPass <https://github.com/CPS-IT/handlebars/blob/main/Classes/DependencyInjection/DataProcessorPass.php>`__
-   -  `ProcessingBridge <https://github.com/CPS-IT/handlebars/blob/main/Classes/DependencyInjection/ProcessingBridge.php>`__
+    - `AbstractDataProcessor <https://github.com/CPS-IT/handlebars/blob/main/Classes/DataProcessing/AbstractDataProcessor.php>`__
+    - `DataProcessorPass <https://github.com/CPS-IT/handlebars/blob/main/Classes/DependencyInjection/DataProcessorPass.php>`__
+    - `ProcessingBridge <https://github.com/CPS-IT/handlebars/blob/main/Classes/DependencyInjection/ProcessingBridge.php>`__

--- a/Documentation/Usage/Extended/SimpleProcessor/Index.rst
+++ b/Documentation/Usage/Extended/SimpleProcessor/Index.rst
@@ -1,6 +1,6 @@
-.. include:: /Includes.rst.txt
+..  include:: /Includes.rst.txt
 
-.. _simple-processor:
+..  _simple-processor:
 
 =================
 `SimpleProcessor`
@@ -11,18 +11,18 @@ by TypoScript, a `SimpleProcessor` is available. This passes the
 transferred data directly to the `Renderer` without any further
 interaction.
 
-.. _simple-processor-usage:
+..  _simple-processor-usage:
 
 Usage
 =====
 
-.. code-block:: typoscript
+..  code-block:: typoscript
 
-   tt_content.tx_myextension_mymodule = USER
-   tt_content.tx_myextension_mymodule {
-       userFunc = Fr\Typo3Handlebars\DataProcessing\SimpleProcessor->process
-       userFunc.templatePath = Extensions/FluidStyledContent/MyModule
-   }
+    tt_content.tx_myextension_mymodule = USER
+    tt_content.tx_myextension_mymodule {
+        userFunc = Fr\Typo3Handlebars\DataProcessing\SimpleProcessor->process
+        userFunc.templatePath = Extensions/FluidStyledContent/MyModule
+    }
 
 As you can see, the `SimpleProcessor` is directly addressed as
 :typoscript:`userFunc`. It already provides the necessary functionality,
@@ -32,13 +32,13 @@ Furthermore it is necessary to indicate a template path with (this normally
 happens in the `Presenter`). The `SimpleProcessor` throws an exception, if
 the template path is not set or invalid.
 
-.. _simple-processor-sources:
+..  _simple-processor-sources:
 
 Sources
 =======
 
-.. seealso::
+..  seealso::
 
-   View the sources on GitHub:
+    View the sources on GitHub:
 
-   -  `SimpleProcessor <https://github.com/CPS-IT/handlebars/blob/main/Classes/DataProcessing/SimpleProcessor.php>`__
+    - `SimpleProcessor <https://github.com/CPS-IT/handlebars/blob/main/Classes/DataProcessing/SimpleProcessor.php>`__

--- a/Documentation/Usage/Extended/UsingTheContentObjectRenderer/Index.rst
+++ b/Documentation/Usage/Extended/UsingTheContentObjectRenderer/Index.rst
@@ -1,6 +1,6 @@
-.. include:: /Includes.rst.txt
+..  include:: /Includes.rst.txt
 
-.. _using-the-content-object-renderer:
+..  _using-the-content-object-renderer:
 
 =================================
 Using the `ContentObjectRenderer`
@@ -12,109 +12,109 @@ be necessary in the `DataProvider`. For this case an interface
 provided, which can be used in combination with the trait
 :php:`Fr\Typo3Handlebars\Traits\ContentObjectRendererAwareTrait`.
 
-.. _content-object-renderer-usage:
+..  _content-object-renderer-usage:
 
 Usage
 =====
 
-.. rst-class:: bignums-xxl
+..  rst-class:: bignums-xxl
 
-#. Transfer of the `ContentObjectRenderer`
+#.  Transfer of the `ContentObjectRenderer`
 
-   If the rendering process is triggered via TypoScript, the
-   `DataProcessor` is automatically assigned the current instance of
-   the `ContentObjectRenderer` (via the :php:`cObj` property). It can
-   then pass this to the `DataProvider`:
+    If the rendering process is triggered via TypoScript, the
+    `DataProcessor` is automatically assigned the current instance of
+    the `ContentObjectRenderer` (via the :php:`cObj` property). It can
+    then pass this to the `DataProvider`:
 
-   ::
+    ::
 
-      # Classes/DataProcessing/CustomProcessor.php
+        # Classes/DataProcessing/CustomProcessor.php
 
-      namespace Vendor\Extension\DataProcessing;
+        namespace Vendor\Extension\DataProcessing;
 
-      use Fr\Typo3Handlebars\DataProcessing\AbstractDataProcessor;
+        use Fr\Typo3Handlebars\DataProcessing\AbstractDataProcessor;
 
-      class CustomProcessor extends AbstractDataProcessor
-      {
-          protected function render(): string
-          {
-              $this->provider->setContentObjectRenderer($this->cObj);
-              // ...
-          }
-      }
+        class CustomProcessor extends AbstractDataProcessor
+        {
+            protected function render(): string
+            {
+                $this->provider->setContentObjectRenderer($this->cObj);
+                // ...
+            }
+        }
 
-#. Assure `ContentObjectRenderer` is available
+#.  Assure `ContentObjectRenderer` is available
 
-   In the `DataProvider`, the existence of the `ContentObjectRenderer`
-   can be easily checked if the associated trait is used:
+    In the `DataProvider`, the existence of the `ContentObjectRenderer`
+    can be easily checked if the associated trait is used:
 
-   ::
+    ::
 
-      # Classes/Data/CustomProvider.php
+        # Classes/Data/CustomProvider.php
 
-      namespace Vendor\Extension\Data;
+        namespace Vendor\Extension\Data;
 
-      use Fr\Typo3Handlebars\ContentObjectRendererAwareInterface;
-      use Fr\Typo3Handlebars\Data\DataProviderInterface;
-      use Fr\Typo3Handlebars\Data\Response\ProviderResponseInterface;
-      use Fr\Typo3Handlebars\Traits\ContentObjectRendererAwareTrait;
+        use Fr\Typo3Handlebars\ContentObjectRendererAwareInterface;
+        use Fr\Typo3Handlebars\Data\DataProviderInterface;
+        use Fr\Typo3Handlebars\Data\Response\ProviderResponseInterface;
+        use Fr\Typo3Handlebars\Traits\ContentObjectRendererAwareTrait;
 
-      class CustomProvider implements DataProviderInterface, ContentObjectRendererAwareInterface
-      {
-          use ContentObjectRendererAwareTrait;
+        class CustomProvider implements DataProviderInterface, ContentObjectRendererAwareInterface
+        {
+            use ContentObjectRendererAwareTrait;
 
-          public function get(array $data): ProviderResponseInterface
-          {
-              $this->assertContentObjectRendererIsAvailable();
-              // ...
-          }
-      }
+            public function get(array $data): ProviderResponseInterface
+            {
+                $this->assertContentObjectRendererIsAvailable();
+                // ...
+            }
+        }
 
-#. Use the `ContentObjectRenderer`
+#.  Use the `ContentObjectRenderer`
 
-   If successful, the `ContentObjectRenderer` can then be used, for example,
-   to parse database content generated using RTE:
+    If successful, the `ContentObjectRenderer` can then be used, for example,
+    to parse database content generated using RTE:
 
-   .. code-block:: diff
+    ..  code-block:: diff
 
-       # Classes/Data/CustomProvider.php
+         # Classes/Data/CustomProvider.php
 
-       namespace Vendor\Extension\Data;
+         namespace Vendor\Extension\Data;
 
-       use Fr\Typo3Handlebars\ContentObjectRendererAwareInterface;
-       use Fr\Typo3Handlebars\Data\DataProviderInterface;
-       use Fr\Typo3Handlebars\Data\Response\ProviderResponseInterface;
-       use Fr\Typo3Handlebars\Traits\ContentObjectRendererAwareTrait;
-      +use Vendor\Extension\Data\Response\CustomProviderResponse;
+         use Fr\Typo3Handlebars\ContentObjectRendererAwareInterface;
+         use Fr\Typo3Handlebars\Data\DataProviderInterface;
+         use Fr\Typo3Handlebars\Data\Response\ProviderResponseInterface;
+         use Fr\Typo3Handlebars\Traits\ContentObjectRendererAwareTrait;
+        +use Vendor\Extension\Data\Response\CustomProviderResponse;
 
-       class CustomProvider implements DataProviderInterface, ContentObjectRendererAwareInterface
-       {
-           use ContentObjectRendererAwareTrait;
+         class CustomProvider implements DataProviderInterface, ContentObjectRendererAwareInterface
+         {
+             use ContentObjectRendererAwareTrait;
 
-           public function get(array $data): ProviderResponseInterface
-           {
-               $this->assertContentObjectRendererIsAvailable();
-      -        // ...
-      +
-      +        $text = $this->parseText($data);
-      +
-      +        return new CustomProviderResponse($text);
-          }
-      +
-      +    private function parseText(string $plaintext): string
-      +    {
-      +        return $this->contentObjectRenderer->parseFunc($plaintext, [], '< lib.parseFunc_RTE');
-      +    }
-       }
+             public function get(array $data): ProviderResponseInterface
+             {
+                 $this->assertContentObjectRendererIsAvailable();
+        -        // ...
+        +
+        +        $text = $this->parseText($data);
+        +
+        +        return new CustomProviderResponse($text);
+            }
+        +
+        +    private function parseText(string $plaintext): string
+        +    {
+        +        return $this->contentObjectRenderer->parseFunc($plaintext, [], '< lib.parseFunc_RTE');
+        +    }
+         }
 
-.. _content-object-renderer-sources:
+..  _content-object-renderer-sources:
 
 Sources
 =======
 
-.. seealso::
+..  seealso::
 
-   View the sources on GitHub:
+    View the sources on GitHub:
 
-   -  `ContentObjectRendererAwareInterface <https://github.com/CPS-IT/handlebars/blob/main/Classes/ContentObjectRendererAwareInterface.php>`__
-   -  `ContentObjectRendererAwareTrait <https://github.com/CPS-IT/handlebars/blob/main/Classes/Traits/ContentObjectRendererAwareTrait.php>`__
+    - `ContentObjectRendererAwareInterface <https://github.com/CPS-IT/handlebars/blob/main/Classes/ContentObjectRendererAwareInterface.php>`__
+    - `ContentObjectRendererAwareTrait <https://github.com/CPS-IT/handlebars/blob/main/Classes/Traits/ContentObjectRendererAwareTrait.php>`__

--- a/Documentation/Usage/Index.rst
+++ b/Documentation/Usage/Index.rst
@@ -1,6 +1,6 @@
-.. include:: /Includes.rst.txt
+..  include:: /Includes.rst.txt
 
-.. _usage:
+..  _usage:
 
 =====
 Usage
@@ -11,8 +11,8 @@ possible applications. Here you can learn how to use the individual
 components of the extension optimally and how to reuse them in your
 own components.
 
-.. toctree::
-   :maxdepth: 3
+..  toctree::
+    :maxdepth: 3
 
-   Basic/Index
-   Extended/Index
+    Basic/Index
+    Extended/Index

--- a/Documentation/genindex.rst
+++ b/Documentation/genindex.rst
@@ -1,7 +1,7 @@
-.. include:: /Includes.rst.txt
+..  include:: /Includes.rst.txt
 
 =====
 Index
 =====
 
-.. Sphinx will insert here the general index automatically.
+..  Sphinx will insert here the general index automatically.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.6'
 
 services:
   docs:
-    image: t3docs/render-documentation:latest
+    image: ghcr.io/t3docs/render-documentation:develop
     command: makehtml
     volumes:
       - .:/PROJECT:ro


### PR DESCRIPTION
Indentation for `.rst` files is now streamlined to 4 spaces. This is now applied to the whole documentation.