### PR TITLE
[TASK] Use PhpStan baseline for ignored errors

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,6 +10,7 @@
 /docker-compose.yml       export-ignore
 /packaging_exclude.php    export-ignore
 /phpstan.neon             export-ignore
+/phpstan-baseline.neon    export-ignore
 /phpunit.ci.xml           export-ignore
 /phpunit.xml              export-ignore
 /rector.php               export-ignore

--- a/packaging_exclude.php
+++ b/packaging_exclude.php
@@ -42,6 +42,7 @@ return [
         'packaging_exclude.php',
         'php-cs-fixer.php',
         'phpstan.neon',
+        'phpstan-baseline.neon',
         'phpunit.ci.xml',
         'phpunit.xml',
         'rector.php',

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,16 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Access to an undefined property Prophecy\\\\Prophecy\\\\ObjectProphecy\\<TYPO3\\\\CMS\\\\Frontend\\\\ContentObject\\\\ContentObjectRenderer\\>\\:\\:\\$data\\.$#"
+			count: 1
+			path: Tests/Unit/DataProcessing/SimpleProcessorTest.php
+
+		-
+			message: "#^Access to an undefined property Prophecy\\\\Prophecy\\\\ObjectProphecy\\<TYPO3\\\\CMS\\\\Frontend\\\\Controller\\\\TypoScriptFrontendController\\>\\:\\:\\$config\\.$#"
+			count: 2
+			path: Tests/Unit/Renderer/HandlebarsRendererTest.php
+
+		-
+			message: "#^Access to an undefined property Prophecy\\\\Prophecy\\\\ObjectProphecy\\<TYPO3\\\\CMS\\\\Frontend\\\\Controller\\\\TypoScriptFrontendController\\>\\:\\:\\$no_cache\\.$#"
+			count: 1
+			path: Tests/Unit/Renderer/HandlebarsRendererTest.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,4 +1,5 @@
 includes:
+	- phpstan-baseline.neon
 	- .Build/vendor/jangregor/phpstan-prophecy/extension.neon
 	- .Build/vendor/phpstan/phpstan-phpunit/extension.neon
 	- .Build/vendor/saschaegerer/phpstan-typo3/extension.neon
@@ -12,10 +13,3 @@ parameters:
 		- Classes
 		- Configuration
 		- Tests
-
-	ignoreErrors:
-		# Property accesses of prophesized objects
-		-
-			message: '#Access to an undefined property Prophecy\\Prophecy\\ObjectProphecy<[a-zA-Z0-9\\_]+>::\$[a-zA-Z0-9_]+\.#'
-			paths:
-				- Tests/Unit/*


### PR DESCRIPTION
We should rather maintain a baseline instead of adding ignored errors to the config file.