### PR TITLE
[BUGFIX] Skip Rector's class name import in some files

### DIFF
--- a/Configuration/Services.php
+++ b/Configuration/Services.php
@@ -26,7 +26,7 @@ namespace Fr\Typo3Handlebars\DependencyInjection;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-return function (/** @noinspection PhpUnusedParameterInspection */ ContainerConfigurator $containerConfigurator, ContainerBuilder $container) {
+return static function (ContainerConfigurator $containerConfigurator, ContainerBuilder $container): void {
     $container->registerExtension(new Extension\HandlebarsExtension());
     $container->addCompilerPass(new DataProcessorPass('handlebars.processor', 'handlebars.compatibility_layer'));
     $container->addCompilerPass(new HandlebarsHelperPass('handlebars.helper', 'handlebars.renderer'));

--- a/rector.php
+++ b/rector.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
 use Rector\Core\ValueObject\PhpVersion;
+use Rector\PostRector\Rector\NameImportingPostRector;
 use Ssch\TYPO3Rector\Configuration\Typo3Option;
 use Ssch\TYPO3Rector\FileProcessor\TypoScript\Rector\v10\v0\ExtbasePersistenceTypoScriptRector;
 use Ssch\TYPO3Rector\FileProcessor\TypoScript\Rector\v9\v0\FileIncludeToImportStatementTypoScriptRector;
@@ -59,6 +60,10 @@ return static function (RectorConfig $rectorConfig): void {
         __DIR__ . '/.github/*',
         __DIR__ . '/config/*',
         __DIR__ . '/var/*',
+        NameImportingPostRector::class => [
+            __DIR__ . '/ext_*.php',
+            __DIR__ . '/Configuration/Services.php',
+        ],
     ]);
 
     // Rewrite your extbase persistence class mapping from typoscript into php according to official docs.


### PR DESCRIPTION
Some files such as `ext_localconf.php` must not have class imports, therefore we must skip the appropriate rule for Rector being applied on those files.