### PR TITLE
[TASK] Switch to `ncipollo/release-action` for new releases

### DIFF
--- a/.github/workflows/cgl.yaml
+++ b/.github/workflows/cgl.yaml
@@ -22,6 +22,7 @@ jobs:
         with:
           php-version: 8.1
           tools: composer:v2, composer-require-checker, composer-unused
+          coverage: none
 
       # Validation
       - name: Validate composer.json

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -64,6 +64,7 @@ jobs:
           php-version: 7.4
           extensions: intl, mbstring, json, zip, curl
           tools: composer:v2
+          coverage: none
 
       # Build dependencies
       - name: Build dependencies

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,9 +26,9 @@ jobs:
       # Create release
       - name: Create release
         id: create-release
-        uses: softprops/action-gh-release@v1
+        uses: ncipollo/release-action@v1
         with:
-          generate_release_notes: true
+          generateReleaseNotes: true
 
   # Job: Publish on TER
   ter-publish:


### PR DESCRIPTION
The previously used action `softprops/action-gh-release` was not properly updated anymore. Thus, we now switch to the actively maintained action `ncipollo/release-action`.