### PR TITLE
[BUGFIX] Fix access to HTML url of generated release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     outputs:
-      release-notes-url: ${{ steps.create-release.outputs.url }}
+      release-notes-url: ${{ steps.create-release.outputs.html_url }}
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
With #78, the GitHub action for release generation was changed. However, the action output differs from the previously used action. This PR fixes access to the HTML url.