### PR TITLE
[BUGFIX] Widen dependency versions via Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,7 +23,7 @@ updates:
     labels:
       - dependencies
     open-pull-requests-limit: 10
-    versioning-strategy: increase-if-necessary
+    versioning-strategy: widen
 
   - package-ecosystem: composer
     directory: 'Resources/Private/Libs/Build'
@@ -35,4 +35,4 @@ updates:
     labels:
       - dependencies
     open-pull-requests-limit: 10
-    versioning-strategy: increase-if-necessary
+    versioning-strategy: widen


### PR DESCRIPTION
Since TYPO3 extensions are considered libraries, we should not increase dependency versions in `composer.json` files. Instead, dependency ranges should be widened, avoiding incompatibilities in terms B/C.