### PR TITLE
[BUGFIX] Allow installation of typo3/coding-standards 0.6.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
 		"saschaegerer/phpstan-typo3": "^1.0",
 		"ssch/typo3-rector": "^1.0",
 		"symfony/event-dispatcher": "^4.4 || ^5.0",
-		"typo3/coding-standards": "^0.7.0",
+		"typo3/coding-standards": "^0.6.0 || ^0.7.0",
 		"typo3/testing-framework": "^6.15"
 	},
 	"autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9b41b3089f6184754a66c652d382d1fe",
+    "content-hash": "f72dba5be1e36d9f52a0cce407e4a352",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",


### PR DESCRIPTION
This is required to keep PHP 7.4 support.