### PR TITLE
[TASK] Use release token in GitHub release job

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,6 +28,7 @@ jobs:
         id: create-release
         uses: ncipollo/release-action@v1
         with:
+          token: ${{ secrets.RELEASE_TOKEN }}
           generateReleaseNotes: true
 
   # Job: Publish on TER


### PR DESCRIPTION
The @cpsitgmbh user may create releases in the future using our organization-wide release token :pray: