### PR TITLE
[BUGFIX] Reflect content object renderer type from assert method

### DIFF
--- a/Classes/Traits/ContentObjectRendererAwareTrait.php
+++ b/Classes/Traits/ContentObjectRendererAwareTrait.php
@@ -43,6 +43,9 @@ trait ContentObjectRendererAwareTrait
         $this->contentObjectRenderer = $contentObjectRenderer;
     }
 
+    /**
+     * @phpstan-assert ContentObjectRenderer $this->contentObjectRenderer
+     */
     protected function assertContentObjectRendererIsAvailable(): void
     {
         if (!($this->contentObjectRenderer instanceof ContentObjectRenderer)) {

--- a/Tests/Unit/Traits/ContentObjectRendererAwareTraitTest.php
+++ b/Tests/Unit/Traits/ContentObjectRendererAwareTraitTest.php
@@ -78,5 +78,7 @@ class ContentObjectRendererAwareTraitTest extends UnitTestCase
         $this->subject->setContentObjectRenderer($contentObjectRenderer);
 
         $this->subject->testAssertContentObjectRendererIsAvailable();
+
+        self::assertSame($contentObjectRenderer, $this->subject->getContentObjectRenderer());
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
 		"jangregor/phpstan-prophecy": "^1.0",
 		"mikey179/vfsstream": "^1.6",
 		"phpspec/prophecy-phpunit": "^2.0",
-		"phpstan/phpstan": "^1.5.5",
+		"phpstan/phpstan": "^1.9",
 		"phpstan/phpstan-phpunit": "^1.1",
 		"phpunit/phpunit": "^9.5",
 		"saschaegerer/phpstan-typo3": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c6151366cf0c9416d1848583120cd0fa",
+    "content-hash": "410c6815e79b20409536e244a67c441a",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",


### PR DESCRIPTION
This PR improves type reflection in `ContentObjectRendererAwareTrait` when using `$this->assertContentObjectRendererIsAvailable()`. When using PHPStan >= 1.9.0 for static code analysis, `$this->contentObjectRenderer` is now treated as a valid instance of `ContentObjectRenderer` after the assertion method has been called successfully.