### PR TITLE
[DOCS] Add compatibility layer type to code example

### DIFF
--- a/Documentation/Compatibility/ExtbaseControllers.rst
+++ b/Documentation/Compatibility/ExtbaseControllers.rst
@@ -33,6 +33,7 @@ about the target extbase controller and actions supported by it.
         tags:
           - name: handlebars.processor
           - name: handlebars.compatibility_layer
+            type: 'extbase_controller'
             controller: 'Vendor\Extension\Controller\MyController'
             actions: 'dummy'
 


### PR DESCRIPTION
The `type` property is required, but was forgotten in the code example. This is fixed now.