### PR TITLE
[TASK] Change order of categories in release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -9,9 +9,6 @@ changelog:
       - question
       - wontfix
   categories:
-    - title: 📖 Documentation
-      labels:
-        - documentation
     - title: ⚡ Breaking
       labels:
         - breaking
@@ -21,12 +18,15 @@ changelog:
     - title: 🚑 Fixed
       labels:
         - bug
-    - title: ⚙️ Dependencies
-      labels:
-        - dependencies
     - title: 👷 Changed
       labels:
         - maintenance
+    - title: 📖 Documentation
+      labels:
+        - documentation
+    - title: ⚙️ Dependencies
+      labels:
+        - dependencies
     - title: Other changes
       labels:
         - "*"


### PR DESCRIPTION
We're currently in a project phase with only few substantial changes to the code base and a rather big amount of dependency maintenance commits by bots. With the current release template actual changes to the code base might not be that obvious to user in a sea of dependabot and renovate PRs.

That is why I'm proposing to change the order of PR categories (i.e. labels) in the release notes.