### PR TITLE
[TASK] Revert "Use composer-unused 0.7 in CI"

### DIFF
--- a/.github/workflows/cgl.yaml
+++ b/.github/workflows/cgl.yaml
@@ -21,8 +21,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: 8.1
-          # @todo switch back to composer-unused 0.8 once https://github.com/composer-unused/composer-unused/issues/444 is resolved
-          tools: composer:v2, composer-require-checker, composer-unused:0.7
+          tools: composer:v2, composer-require-checker, composer-unused
           coverage: none
 
       # Validation


### PR DESCRIPTION
`composer-unused` 0.8.7 was released, containing a fixed PHAR file.

This reverts commit de0155f9146982cf0a63cb2c381e02900b3eff8e.