### PR TITLE
[TASK] Use phpstan/extension-installer and clean up phpstan.neon

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
 		"ergebnis/composer-normalize": "^2.15",
 		"helmich/typo3-typoscript-lint": "^2.5 || ^3.0",
 		"mikey179/vfsstream": "^1.6.7",
+		"phpstan/extension-installer": "^1.3",
 		"phpstan/phpstan": "^1.9",
 		"phpstan/phpstan-phpunit": "^1.1",
 		"phpunit/phpunit": "^9.5",
@@ -56,6 +57,7 @@
 	"config": {
 		"allow-plugins": {
 			"ergebnis/composer-normalize": true,
+			"phpstan/extension-installer": true,
 			"typo3/class-alias-loader": true,
 			"typo3/cms-composer-installers": true
 		},

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "065a89c0505669347c0b5abdbc80449b",
+    "content-hash": "33e7d40cd2c01599465c8397b35057b6",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -7019,6 +7019,50 @@
                 "source": "https://github.com/phar-io/version/tree/3.2.1"
             },
             "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "phpstan/extension-installer",
+            "version": "1.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/extension-installer.git",
+                "reference": "f45734bfb9984c6c56c4486b71230355f066a58a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/extension-installer/zipball/f45734bfb9984c6c56c4486b71230355f066a58a",
+                "reference": "f45734bfb9984c6c56c4486b71230355f066a58a",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^2.0",
+                "php": "^7.2 || ^8.0",
+                "phpstan/phpstan": "^1.9.0"
+            },
+            "require-dev": {
+                "composer/composer": "^2.0",
+                "php-parallel-lint/php-parallel-lint": "^1.2.0",
+                "phpstan/phpstan-strict-rules": "^0.11 || ^0.12 || ^1.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "PHPStan\\ExtensionInstaller\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\ExtensionInstaller\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Composer plugin for automatic installation of PHPStan extensions",
+            "support": {
+                "issues": "https://github.com/phpstan/extension-installer/issues",
+                "source": "https://github.com/phpstan/extension-installer/tree/1.3.1"
+            },
+            "time": "2023-05-24T08:59:17+00:00"
         },
         {
             "name": "phpstan/phpstan",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,11 +1,4 @@
-includes:
-	- .Build/vendor/phpstan/phpstan-phpunit/extension.neon
-	- .Build/vendor/saschaegerer/phpstan-typo3/extension.neon
-
 parameters:
-	bootstrapFiles:
-		- .Build/vendor/typo3/testing-framework/Resources/Core/Build/UnitTestsBootstrap.php
-
 	level: 8
 	paths:
 		- Classes


### PR DESCRIPTION
This PR requires and includes `phpstan/extension-installer`. In addition, superfluous config from `phpstan.neon` is removed.