### PR TITLE
[BUGFIX] Use proper Renovate constraints for libraries build dir

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,6 +15,14 @@
 			"constraints": {
 				"php": "8.1.*"
 			}
+		},
+		{
+			"matchFileNames": [
+				"Resources/Private/Libs/Build/composer.json"
+			],
+			"constraints": {
+				"php": "7.4.*"
+			}
 		}
 	]
 }


### PR DESCRIPTION
This PR adds the correct Renovate PHP version constraint for `Resources/Private/Libs/Build/composer.json`.