### PR TITLE
[FEATURE] Introduce `block`, `content` and `extend` helpers

### DIFF
--- a/Classes/Renderer/Component/Layout/HandlebarsLayout.php
+++ b/Classes/Renderer/Component/Layout/HandlebarsLayout.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "handlebars".
+ *
+ * Copyright (C) 2024 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace Fr\Typo3Handlebars\Renderer\Component\Layout;
+
+/**
+ * HandlebarsLayout
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-2.0-or-later
+ */
+class HandlebarsLayout
+{
+    protected bool $parsed = false;
+
+    /**
+     * @param callable $parseFunction
+     * @param array<string, HandlebarsLayoutAction[]> $actions
+     */
+    public function __construct(
+        protected $parseFunction,
+        protected array $actions = [],
+    ) {}
+
+    public function parse(): void
+    {
+        ($this->parseFunction)();
+        $this->parsed = true;
+    }
+
+    public function addAction(string $name, HandlebarsLayoutAction $action): void
+    {
+        if (!isset($this->actions[$name])) {
+            $this->actions[$name] = [];
+        }
+        $this->actions[$name][] = $action;
+    }
+
+    /**
+     * @return array<string, HandlebarsLayoutAction[]>|HandlebarsLayoutAction[]
+     */
+    public function getActions(string $name = null): array
+    {
+        if ($name === null) {
+            return $this->actions;
+        }
+
+        return $this->actions[$name] ?? [];
+    }
+
+    public function hasAction(string $name): bool
+    {
+        return \array_key_exists($name, $this->actions);
+    }
+
+    public function isParsed(): bool
+    {
+        return $this->parsed;
+    }
+
+    public function setParsed(bool $parsed): self
+    {
+        $this->parsed = $parsed;
+        return $this;
+    }
+}

--- a/Classes/Renderer/Component/Layout/HandlebarsLayoutAction.php
+++ b/Classes/Renderer/Component/Layout/HandlebarsLayoutAction.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "handlebars".
+ *
+ * Copyright (C) 2024 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace Fr\Typo3Handlebars\Renderer\Component\Layout;
+
+use Fr\Typo3Handlebars\Exception;
+
+/**
+ * HandlebarsLayoutAction
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-2.0-or-later
+ */
+class HandlebarsLayoutAction
+{
+    public const REPLACE = 'replace';
+    public const APPEND = 'append';
+    public const PREPEND = 'prepend';
+
+    protected readonly string $mode;
+
+    /**
+     * @param array<string, mixed> $data
+     * @param callable $renderFunction
+     * @throws Exception\UnsupportedTypeException
+     */
+    public function __construct(
+        protected readonly array $data,
+        protected $renderFunction,
+        string $mode = self::REPLACE,
+    ) {
+        $this->mode = strtolower($mode);
+        $this->validate();
+    }
+
+    /**
+     * @param string $value
+     * @return string
+     * @throws Exception\UnsupportedTypeException
+     */
+    public function render(string $value): string
+    {
+        $renderResult = ($this->renderFunction)($this->data);
+
+        return match ($this->mode) {
+            self::APPEND => $value . $renderResult,
+            self::PREPEND => $renderResult . $value,
+            self::REPLACE => $renderResult,
+            default => throw Exception\UnsupportedTypeException::create($this->mode),
+        };
+    }
+
+    /**
+     * @return string[]
+     */
+    protected function getSupportedModes(): array
+    {
+        return [
+            self::REPLACE,
+            self::APPEND,
+            self::PREPEND,
+        ];
+    }
+
+    /**
+     * @throws Exception\UnsupportedTypeException
+     */
+    protected function validate(): void
+    {
+        if (!\in_array($this->mode, $this->getSupportedModes(), true)) {
+            throw Exception\UnsupportedTypeException::create($this->mode);
+        }
+    }
+}

--- a/Classes/Renderer/Helper/BlockHelper.php
+++ b/Classes/Renderer/Helper/BlockHelper.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "handlebars".
+ *
+ * Copyright (C) 2024 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace Fr\Typo3Handlebars\Renderer\Helper;
+
+use Fr\Typo3Handlebars\Exception;
+use Fr\Typo3Handlebars\Renderer;
+
+/**
+ * BlockHelper
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-2.0-or-later
+ * @see https://github.com/shannonmoeller/handlebars-layouts#block-name
+ */
+class BlockHelper implements HelperInterface
+{
+    /**
+     * @param array<string, mixed> $options
+     * @throws Exception\UnsupportedTypeException
+     */
+    public function evaluate(string $name, array $options): string
+    {
+        $data = $options['_this'];
+        $actions = $data['_layoutActions'] ?? [];
+        $stack = $data['_layoutStack'] ?? [];
+
+        // Parse layouts and fetch all parsed layout actions for the requested block
+        while (!empty($stack)) {
+            /** @var Renderer\Component\Layout\HandlebarsLayout $layout */
+            $layout = array_shift($stack);
+            if (!$layout->isParsed()) {
+                $layout->parse();
+            }
+            $actions = array_merge($actions, $layout->getActions($name));
+        }
+
+        // Walk through layout actions and apply them to the rendered block
+        $fn = $options['fn'] ?? static fn() => '';
+
+        return array_reduce(
+            $actions,
+            static fn(string $value, Renderer\Component\Layout\HandlebarsLayoutAction $action): string => $action->render($value),
+            $fn($data),
+        );
+    }
+}

--- a/Classes/Renderer/Helper/ContentHelper.php
+++ b/Classes/Renderer/Helper/ContentHelper.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "handlebars".
+ *
+ * Copyright (C) 2024 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace Fr\Typo3Handlebars\Renderer\Helper;
+
+use Fr\Typo3Handlebars\Renderer;
+use Psr\Log;
+
+/**
+ * ContentHelper
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-2.0-or-later
+ * @see https://github.com/shannonmoeller/handlebars-layouts#content-name-modeappendprependreplace
+ */
+class ContentHelper implements HelperInterface
+{
+    public function __construct(
+        protected readonly Log\LoggerInterface $logger,
+    ) {}
+
+    /**
+     * @param array<string, mixed> $options
+     * @return string|bool
+     */
+    public function evaluate(string $name, array $options)
+    {
+        $data = $options['_this'];
+        $mode = $options['hash']['mode'] ?? Renderer\Component\Layout\HandlebarsLayoutAction::REPLACE;
+        $layoutStack = $this->getLayoutStack($options);
+
+        // Early return if "content" helper is requested outside of an "extend" helper block
+        if (empty($layoutStack)) {
+            $this->logger->error('Handlebars layout helper "content" can only be used within an "extend" helper block!', ['name' => $name]);
+            return '';
+        }
+
+        // Get upper layout from stack
+        $layout = end($layoutStack);
+
+        // Usage in conditional context: Test whether given required block is registered
+        if (!\is_callable($options['fn'] ?? '')) {
+            if (!$layout->isParsed()) {
+                $layout->parse();
+            }
+
+            return $layout->hasAction($name);
+        }
+
+        // Add concrete action for the requested block
+        $action = new Renderer\Component\Layout\HandlebarsLayoutAction($data, $options['fn'], $mode);
+        $layout->addAction($name, $action);
+
+        // This helper does not return any content, it's just here to register layout actions
+        return '';
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     * @return Renderer\Component\Layout\HandlebarsLayout[]
+     */
+    protected function getLayoutStack(array $options): array
+    {
+        // Fetch layout stack from current context
+        if (isset($options['_this']['_layoutStack'])) {
+            return $options['_this']['_layoutStack'];
+        }
+
+        // Early return if only context is currently processed
+        if (!isset($options['contexts'])) {
+            return [];
+        }
+
+        // Fetch layout stack from previous contexts
+        while (!empty($options['contexts'])) {
+            $context = array_pop($options['contexts']);
+            if (isset($context['_layoutStack'])) {
+                return $context['_layoutStack'];
+            }
+        }
+
+        return [];
+    }
+}

--- a/Classes/Renderer/Helper/ExtendHelper.php
+++ b/Classes/Renderer/Helper/ExtendHelper.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "handlebars".
+ *
+ * Copyright (C) 2024 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace Fr\Typo3Handlebars\Renderer\Helper;
+
+use Fr\Typo3Handlebars\Renderer;
+
+/**
+ * ExtendHelper
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-2.0-or-later
+ * @see https://github.com/shannonmoeller/handlebars-layouts#extend-partial-context-keyvalue-
+ */
+class ExtendHelper implements HelperInterface
+{
+    public function __construct(
+        protected readonly Renderer\RendererInterface $renderer,
+    ) {}
+
+    public function evaluate(string $name): string
+    {
+        // Get helper options
+        $arguments = \func_get_args();
+        array_shift($arguments);
+        $options = array_pop($arguments);
+
+        // Custom context is optional
+        $customContext = [];
+        if ($arguments !== []) {
+            $customContext = (array)array_pop($arguments);
+        }
+
+        // Create new handlebars layout item
+        $fn = \is_callable($options['fn'] ?? '') ? $options['fn'] : static fn(): string => '';
+        $handlebarsLayout = new Renderer\Component\Layout\HandlebarsLayout($fn);
+
+        // Add layout to layout stack
+        $data = &$options['_this'];
+        if (!isset($data['_layoutStack'])) {
+            $data['_layoutStack'] = [];
+        }
+        $data['_layoutStack'][] = $handlebarsLayout;
+
+        // Merge data with supplied data
+        $renderData = array_replace_recursive($options['_this'], $customContext, $options['hash']);
+
+        // Render layout with merged data
+        return $this->renderer->render($name, $renderData);
+    }
+}

--- a/Tests/Functional/Fixtures/test_extension/Classes/JsonHelper.php
+++ b/Tests/Functional/Fixtures/test_extension/Classes/JsonHelper.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "handlebars".
+ *
+ * Copyright (C) 2024 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace Fr\Typo3Handlebars\TestExtension;
+
+use Fr\Typo3Handlebars\Renderer;
+use LightnCandy\SafeString;
+
+/**
+ * JsonHelper
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-2.0-or-later
+ */
+final class JsonHelper implements Renderer\Helper\HelperInterface
+{
+    /**
+     * @param array<string, mixed> $context
+     */
+    public function encode(array $context): SafeString
+    {
+        return new SafeString(json_encode($context['_this'], JSON_THROW_ON_ERROR));
+    }
+}

--- a/Tests/Functional/Fixtures/test_extension/Resources/Templates/main-layout-conditional-block.hbs
+++ b/Tests/Functional/Fixtures/test_extension/Resources/Templates/main-layout-conditional-block.hbs
@@ -1,0 +1,4 @@
+{{#if (content "second")}}
+    {{block "main"}}
+    {{block "second"}}
+{{/if}}

--- a/Tests/Functional/Fixtures/test_extension/Resources/Templates/main-layout-content-only.hbs
+++ b/Tests/Functional/Fixtures/test_extension/Resources/Templates/main-layout-content-only.hbs
@@ -1,0 +1,3 @@
+{{#content "main"}}
+    Hello world!
+{{/content}}

--- a/Tests/Functional/Fixtures/test_extension/Resources/Templates/main-layout-extended-with-conditional-contents.hbs
+++ b/Tests/Functional/Fixtures/test_extension/Resources/Templates/main-layout-extended-with-conditional-contents.hbs
@@ -1,0 +1,11 @@
+{{#extend templateName}}
+    {{#content "main"}}
+        main block
+    {{/content}}
+
+    {{#if renderSecondBlock}}
+        {{#content "second"}}
+            second block
+        {{/content}}
+    {{/if}}
+{{/extend}}

--- a/Tests/Functional/Fixtures/test_extension/Resources/Templates/main-layout-extended.hbs
+++ b/Tests/Functional/Fixtures/test_extension/Resources/Templates/main-layout-extended.hbs
@@ -1,0 +1,14 @@
+{{#extend templateName}}
+    {{#content "main" mode="append"}}
+        injected
+    {{/content}}
+    {{#content "second" mode="prepend"}}
+        injected
+    {{/content}}
+    {{#content "third" mode="replace"}}
+        injected
+    {{/content}}
+    {{#content "fourth"}}
+        injected
+    {{/content}}
+{{/extend}}

--- a/Tests/Functional/Fixtures/test_extension/Resources/Templates/simple-layout-extended-with-context.hbs
+++ b/Tests/Functional/Fixtures/test_extension/Resources/Templates/simple-layout-extended-with-context.hbs
@@ -1,0 +1,1 @@
+{{#extend "@simple-layout" customContext}}{{/extend}}

--- a/Tests/Functional/Fixtures/test_extension/Resources/Templates/simple-layout-extended.hbs
+++ b/Tests/Functional/Fixtures/test_extension/Resources/Templates/simple-layout-extended.hbs
@@ -1,0 +1,1 @@
+{{#extend "@simple-layout"}}{{/extend}}

--- a/Tests/Functional/Fixtures/test_extension/Resources/Templates/simple-layout.hbs
+++ b/Tests/Functional/Fixtures/test_extension/Resources/Templates/simple-layout.hbs
@@ -1,0 +1,1 @@
+{{jsonEncode}}

--- a/Tests/Functional/Renderer/Helper/ContentHelperTest.php
+++ b/Tests/Functional/Renderer/Helper/ContentHelperTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "handlebars".
+ *
+ * Copyright (C) 2024 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace Fr\Typo3Handlebars\Tests\Functional\Renderer\Helper;
+
+use Fr\Typo3Handlebars as Src;
+use Fr\Typo3Handlebars\Tests;
+use PHPUnit\Framework;
+use Psr\Log;
+use Symfony\Component\EventDispatcher;
+use TYPO3\TestingFramework;
+
+/**
+ * ContentHelperTest
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-2.0-or-later
+ */
+#[Framework\Attributes\CoversClass(Src\Renderer\Helper\ContentHelper::class)]
+final class ContentHelperTest extends TestingFramework\Core\Functional\FunctionalTestCase
+{
+    use Tests\Unit\HandlebarsTemplateResolverTrait;
+
+    protected bool $initializeDatabase = false;
+
+    protected array $testExtensionsToLoad = [
+        'test_extension',
+    ];
+
+    protected Src\Renderer\HandlebarsRenderer $renderer;
+    protected Log\Test\TestLogger $logger;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->logger = new Log\Test\TestLogger();
+        $this->templateResolver = new Src\Renderer\Template\FlatTemplateResolver($this->getTemplatePaths());
+        $this->renderer = new Src\Renderer\HandlebarsRenderer(
+            new Src\Cache\NullCache(),
+            new EventDispatcher\EventDispatcher(),
+            $this->logger,
+            $this->templateResolver,
+        );
+        $this->renderer->registerHelper('extend', [new Src\Renderer\Helper\ExtendHelper($this->renderer), 'evaluate']);
+        $this->renderer->registerHelper('content', [new Src\Renderer\Helper\ContentHelper($this->logger), 'evaluate']);
+        $this->renderer->registerHelper('block', [new Src\Renderer\Helper\BlockHelper(), 'evaluate']);
+    }
+
+    #[Framework\Attributes\Test]
+    public function helperCanBeCalledFromExtendedLayout(): void
+    {
+        $actual = trim($this->renderer->render('@main-layout-extended', [
+            'templateName' => '@main-layout',
+        ]));
+        $expected = implode(PHP_EOL, [
+            'this is the main block:',
+            '',
+            '[ ]+main block',
+            '[ ]+injected',
+            '',
+            'this is the second block:',
+            '',
+            '[ ]+injected',
+            '[ ]+second block',
+            '',
+            'this is the third block:',
+            '',
+            '[ ]+injected',
+            '',
+            'this is the fourth block:',
+            '',
+            '[ ]+injected',
+            '',
+            'this is the end. bye bye',
+        ]);
+
+        self::assertMatchesRegularExpression('/^' . $expected . '$/', $actual);
+    }
+
+    #[Framework\Attributes\Test]
+    public function helperCannotBeCalledOutsideOfExtendedLayout(): void
+    {
+        $this->renderer->render('@main-layout-content-only');
+
+        self::assertTrue(
+            $this->logger->hasError([
+                'message' => 'Handlebars layout helper "content" can only be used within an "extend" helper block!',
+                'context' => [
+                    'name' => 'main',
+                ],
+            ])
+        );
+    }
+
+    #[Framework\Attributes\Test]
+    #[Framework\Attributes\DataProvider('helperCanBeCalledToConditionallyRenderBlocksDataProvider')]
+    public function helperCanBeCalledToConditionallyRenderBlocks(bool $renderSecondBlock, string $expected): void
+    {
+        $actual = trim($this->renderer->render('@main-layout-extended-with-conditional-contents', [
+            'templateName' => '@main-layout-conditional-block',
+            'renderSecondBlock' => $renderSecondBlock,
+        ]));
+
+        self::assertMatchesRegularExpression('/^' . $expected . '$/', $actual);
+    }
+
+    /**
+     * @return \Generator<string, array{bool, string}>
+     */
+    public static function helperCanBeCalledToConditionallyRenderBlocksDataProvider(): \Generator
+    {
+        yield 'without second block' => [false, ''];
+        yield 'with second block' => [true, 'main block\n+[ ]+second block'];
+    }
+
+    public function getTemplateRootPath(): string
+    {
+        return 'EXT:test_extension/Resources/Templates/';
+    }
+}

--- a/Tests/Functional/Renderer/Helper/ExtendHelperTest.php
+++ b/Tests/Functional/Renderer/Helper/ExtendHelperTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "handlebars".
+ *
+ * Copyright (C) 2024 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace Fr\Typo3Handlebars\Tests\Functional\Renderer\Helper;
+
+use Fr\Typo3Handlebars as Src;
+use Fr\Typo3Handlebars\TestExtension;
+use Fr\Typo3Handlebars\Tests;
+use PHPUnit\Framework;
+use Psr\Log;
+use Symfony\Component\EventDispatcher;
+use TYPO3\TestingFramework;
+
+/**
+ * ExtendHelperTest
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-2.0-or-later
+ */
+#[Framework\Attributes\CoversClass(Src\Renderer\Helper\ExtendHelper::class)]
+final class ExtendHelperTest extends TestingFramework\Core\Functional\FunctionalTestCase
+{
+    use Tests\Unit\HandlebarsTemplateResolverTrait;
+
+    protected bool $initializeDatabase = false;
+
+    protected array $testExtensionsToLoad = [
+        'test_extension',
+    ];
+
+    protected Src\Renderer\HandlebarsRenderer $renderer;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->templateResolver = new Src\Renderer\Template\FlatTemplateResolver($this->getTemplatePaths());
+        $this->renderer = new Src\Renderer\HandlebarsRenderer(
+            new Src\Cache\NullCache(),
+            new EventDispatcher\EventDispatcher(),
+            new Log\NullLogger(),
+            $this->templateResolver,
+        );
+        $this->renderer->registerHelper('extend', [new Src\Renderer\Helper\ExtendHelper($this->renderer), 'evaluate']);
+        $this->renderer->registerHelper('jsonEncode', [new TestExtension\JsonHelper(), 'encode']);
+    }
+
+    #[Framework\Attributes\Test]
+    public function helperCanBeCalledWithoutCustomContext(): void
+    {
+        $actual = trim($this->renderer->render('@simple-layout-extended'));
+        $expected = [];
+
+        self::assertJson($actual);
+
+        $json = json_decode($actual, true);
+        unset($json['_layoutStack']);
+
+        self::assertSame($expected, $json);
+    }
+
+    #[Framework\Attributes\Test]
+    public function helperCanBeCalledWithCustomContext(): void
+    {
+        $actual = trim($this->renderer->render('@simple-layout-extended-with-context', [
+            'customContext' => [
+                'foo' => 'baz',
+            ],
+        ]));
+        $expected = [
+            'customContext' => [
+                'foo' => 'baz',
+            ],
+            'foo' => 'baz',
+        ];
+
+        self::assertJson($actual);
+
+        $json = json_decode($actual, true);
+        unset($json['_layoutStack']);
+
+        self::assertSame($expected, $json);
+    }
+
+    #[Framework\Attributes\Test]
+    public function helperReplacesVariablesCorrectlyInAllContexts(): void
+    {
+        $actual = trim($this->renderer->render('@simple-layout-extended-with-context', [
+            'foo' => 123,
+            'customContext' => [
+                'foo' => 456,
+            ],
+        ]));
+
+        $expected = [
+            'foo' => 456,
+            'customContext' => [
+                'foo' => 456,
+            ],
+        ];
+
+        self::assertJson($actual);
+
+        $json = json_decode($actual, true);
+        unset($json['_layoutStack']);
+
+        self::assertSame($expected, $json);
+    }
+
+    public function getTemplateRootPath(): string
+    {
+        return 'EXT:test_extension/Resources/Templates/';
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
 		"armin/editorconfig-cli": "^1.8 || ^2.0",
 		"cpsit/typo3-handlebars-test-extension": "1.0.0",
 		"ergebnis/composer-normalize": "^2.15",
+		"fig/log-test": "^1.1",
 		"friendsofphp/php-cs-fixer": "^3.57",
 		"helmich/typo3-typoscript-lint": "^2.5 || ^3.0",
 		"mikey179/vfsstream": "^1.6.7",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c41bb03f6dab0a8653d8ae9d7a1050d8",
+    "content-hash": "43b5fd23e44d71a6af68c8704ad7cf15",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -6481,6 +6481,52 @@
                 }
             ],
             "time": "2024-08-06T10:04:20+00:00"
+        },
+        {
+            "name": "fig/log-test",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log-test.git",
+                "reference": "02d6eaf8b09784b7adacf57a3c951bad95229a7f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log-test/zipball/02d6eaf8b09784b7adacf57a3c951bad95229a7f",
+                "reference": "02d6eaf8b09784b7adacf57a3c951bad95229a7f",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.0",
+                "psr/log": "^2.0 | ^3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.0 | ^9.0",
+                "squizlabs/php_codesniffer": "^3.6"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/",
+                    "role": "Organisation"
+                }
+            ],
+            "description": "Test utilities for the psr/log package that backs the PSR-3 specification.",
+            "support": {
+                "issues": "https://github.com/php-fig/log-test/issues",
+                "source": "https://github.com/php-fig/log-test/tree/1.1.0"
+            },
+            "time": "2022-10-18T05:33:27+00:00"
         },
         {
             "name": "friendsofphp/php-cs-fixer",


### PR DESCRIPTION
This PR adds the `block`, `content` and `extend` helpers, inspired by the appropriate [JS implementation from `handlebars_layouts`](https://github.com/shannonmoeller/handlebars-layouts).