### PR TITLE
[FEATURE] Introduce `#[AsHelper]` attribute for helper DI registration

### DIFF
--- a/Classes/Attribute/AsHelper.php
+++ b/Classes/Attribute/AsHelper.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of the TYPO3 CMS extension "handlebars".
  *
- * Copyright (C) 2020 Elias Häußler <e.haeussler@familie-redlich.de>
+ * Copyright (C) 2024 Elias Häußler <e.haeussler@familie-redlich.de>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -21,29 +21,21 @@ declare(strict_types=1);
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-namespace Fr\Typo3Handlebars\Renderer\Helper;
-
-use Fr\Typo3Handlebars\Attribute\AsHelper;
-use TYPO3\CMS\Core\Utility\DebugUtility;
+namespace Fr\Typo3Handlebars\Attribute;
 
 /**
- * VarDumpHelper
+ * AsHelper
  *
  * @author Elias Häußler <e.haeussler@familie-redlich.de>
  * @license GPL-2.0-or-later
  */
-class VarDumpHelper implements HelperInterface
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD)]
+final readonly class AsHelper
 {
-    /**
-     * @param array<string|int, mixed> $context
-     */
-    #[AsHelper('varDump')]
-    public static function evaluate(array $context): string
-    {
-        \ob_start();
+    public const TAG_NAME = 'handlebars.helper';
 
-        DebugUtility::debug($context['_this']);
-
-        return (string)\ob_get_clean();
-    }
+    public function __construct(
+        public string $identifier,
+        public ?string $method = null,
+    ) {}
 }

--- a/Classes/Cache/HandlebarsCache.php
+++ b/Classes/Cache/HandlebarsCache.php
@@ -23,6 +23,8 @@ declare(strict_types=1);
 
 namespace Fr\Typo3Handlebars\Cache;
 
+use Symfony\Component\DependencyInjection\Attribute\AsAlias;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use TYPO3\CMS\Core\Cache\Frontend\FrontendInterface;
 
 /**
@@ -31,9 +33,11 @@ use TYPO3\CMS\Core\Cache\Frontend\FrontendInterface;
  * @author Elias Häußler <e.haeussler@familie-redlich.de>
  * @license GPL-2.0-or-later
  */
+#[AsAlias('handlebars.cache')]
 class HandlebarsCache implements CacheInterface
 {
     public function __construct(
+        #[Autowire('@cache.handlebars')]
         protected readonly FrontendInterface $cache,
     ) {}
 

--- a/Classes/Compatibility/View/HandlebarsViewResolver.php
+++ b/Classes/Compatibility/View/HandlebarsViewResolver.php
@@ -25,6 +25,7 @@ namespace Fr\Typo3Handlebars\Compatibility\View;
 
 use Fr\Typo3Handlebars\DataProcessing\DataProcessorInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autoconfigure;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Mvc\View\GenericViewResolver;
 use TYPO3Fluid\Fluid\View\ViewInterface;
@@ -35,6 +36,7 @@ use TYPO3Fluid\Fluid\View\ViewInterface;
  * @author Elias Häußler <e.haeussler@familie-redlich.de>
  * @license GPL-2.0-or-later
  */
+#[Autoconfigure(public: true)]
 class HandlebarsViewResolver extends GenericViewResolver
 {
     /**

--- a/Classes/DataProcessing/SimpleProcessor.php
+++ b/Classes/DataProcessing/SimpleProcessor.php
@@ -27,6 +27,7 @@ use Fr\Typo3Handlebars\Exception\InvalidTemplateFileException;
 use Fr\Typo3Handlebars\Renderer\RendererInterface;
 use Fr\Typo3Handlebars\Traits\ErrorHandlingTrait;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autoconfigure;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 
 /**
@@ -35,6 +36,7 @@ use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
  * @author Elias Häußler <e.haeussler@familie-redlich.de>
  * @license GPL-2.0-or-later
  */
+#[Autoconfigure(public: true)]
 class SimpleProcessor implements DataProcessorInterface
 {
     use ErrorHandlingTrait;

--- a/Classes/Renderer/HandlebarsRenderer.php
+++ b/Classes/Renderer/HandlebarsRenderer.php
@@ -38,6 +38,9 @@ use LightnCandy\Partial;
 use LightnCandy\Runtime;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\AsAlias;
+use Symfony\Component\DependencyInjection\Attribute\Autoconfigure;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 
@@ -47,6 +50,8 @@ use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
  * @author Elias Häußler <e.haeussler@familie-redlich.de>
  * @license GPL-2.0-or-later
  */
+#[AsAlias('handlebars.renderer')]
+#[Autoconfigure(tags: ['handlebars.renderer'])]
 class HandlebarsRenderer implements RendererInterface, HelperAwareInterface
 {
     use HandlebarsHelperTrait;
@@ -57,11 +62,15 @@ class HandlebarsRenderer implements RendererInterface, HelperAwareInterface
      * @param array<string|int, mixed> $defaultData
      */
     public function __construct(
+        #[Autowire('@handlebars.cache')]
         protected readonly CacheInterface $cache,
         protected readonly EventDispatcherInterface $eventDispatcher,
         protected readonly LoggerInterface $logger,
+        #[Autowire('@handlebars.template_resolver')]
         protected readonly TemplateResolverInterface $templateResolver,
+        #[Autowire('@handlebars.partial_resolver')]
         protected readonly ?TemplateResolverInterface $partialResolver = null,
+        #[Autowire('%handlebars.default_data%')]
         protected array $defaultData = [],
     ) {
         $this->debugMode = $this->isDebugModeEnabled();

--- a/Classes/Renderer/Helper/BlockHelper.php
+++ b/Classes/Renderer/Helper/BlockHelper.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace Fr\Typo3Handlebars\Renderer\Helper;
 
+use Fr\Typo3Handlebars\Attribute;
 use Fr\Typo3Handlebars\Exception;
 use Fr\Typo3Handlebars\Renderer;
 
@@ -33,12 +34,13 @@ use Fr\Typo3Handlebars\Renderer;
  * @license GPL-2.0-or-later
  * @see https://github.com/shannonmoeller/handlebars-layouts#block-name
  */
-class BlockHelper implements HelperInterface
+final readonly class BlockHelper implements HelperInterface
 {
     /**
      * @param array<string, mixed> $options
      * @throws Exception\UnsupportedTypeException
      */
+    #[Attribute\AsHelper('block')]
     public function evaluate(string $name, array $options): string
     {
         $data = $options['_this'];

--- a/Classes/Renderer/Helper/ContentHelper.php
+++ b/Classes/Renderer/Helper/ContentHelper.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace Fr\Typo3Handlebars\Renderer\Helper;
 
+use Fr\Typo3Handlebars\Attribute;
 use Fr\Typo3Handlebars\Renderer;
 use Psr\Log;
 
@@ -33,16 +34,17 @@ use Psr\Log;
  * @license GPL-2.0-or-later
  * @see https://github.com/shannonmoeller/handlebars-layouts#content-name-modeappendprependreplace
  */
-class ContentHelper implements HelperInterface
+final readonly class ContentHelper implements HelperInterface
 {
     public function __construct(
-        protected readonly Log\LoggerInterface $logger,
+        private Log\LoggerInterface $logger,
     ) {}
 
     /**
      * @param array<string, mixed> $options
      * @return string|bool
      */
+    #[Attribute\AsHelper('content')]
     public function evaluate(string $name, array $options)
     {
         $data = $options['_this'];

--- a/Classes/Renderer/Helper/ExtendHelper.php
+++ b/Classes/Renderer/Helper/ExtendHelper.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace Fr\Typo3Handlebars\Renderer\Helper;
 
+use Fr\Typo3Handlebars\Attribute;
 use Fr\Typo3Handlebars\Renderer;
 
 /**
@@ -32,12 +33,13 @@ use Fr\Typo3Handlebars\Renderer;
  * @license GPL-2.0-or-later
  * @see https://github.com/shannonmoeller/handlebars-layouts#extend-partial-context-keyvalue-
  */
-class ExtendHelper implements HelperInterface
+final readonly class ExtendHelper implements HelperInterface
 {
     public function __construct(
-        protected readonly Renderer\RendererInterface $renderer,
+        private Renderer\RendererInterface $renderer,
     ) {}
 
+    #[Attribute\AsHelper('extend')]
     public function evaluate(string $name): string
     {
         // Get helper options

--- a/Classes/Renderer/Helper/RenderHelper.php
+++ b/Classes/Renderer/Helper/RenderHelper.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace Fr\Typo3Handlebars\Renderer\Helper;
 
+use Fr\Typo3Handlebars\Attribute;
 use Fr\Typo3Handlebars\DataProcessing;
 use Fr\Typo3Handlebars\Exception;
 use Fr\Typo3Handlebars\Renderer;
@@ -37,17 +38,18 @@ use TYPO3\CMS\Frontend;
  * @license GPL-2.0-or-later
  * @see https://github.com/frctl/fractal/blob/main/packages/handlebars/src/helpers/render.js
  */
-class RenderHelper implements HelperInterface
+final readonly class RenderHelper implements HelperInterface
 {
     public function __construct(
-        protected readonly Renderer\RendererInterface $renderer,
-        protected readonly Core\TypoScript\TypoScriptService $typoScriptService,
-        protected readonly Frontend\ContentObject\ContentObjectRenderer $contentObjectRenderer,
+        private Renderer\RendererInterface $renderer,
+        private Core\TypoScript\TypoScriptService $typoScriptService,
+        private Frontend\ContentObject\ContentObjectRenderer $contentObjectRenderer,
     ) {}
 
     /**
      * @throws Exception\InvalidConfigurationException
      */
+    #[Attribute\AsHelper('render')]
     public function evaluate(string $name): SafeString
     {
         // Get helper options

--- a/Classes/Renderer/Helper/VarDumpHelper.php
+++ b/Classes/Renderer/Helper/VarDumpHelper.php
@@ -23,8 +23,8 @@ declare(strict_types=1);
 
 namespace Fr\Typo3Handlebars\Renderer\Helper;
 
-use Fr\Typo3Handlebars\Attribute\AsHelper;
-use TYPO3\CMS\Core\Utility\DebugUtility;
+use Fr\Typo3Handlebars\Attribute;
+use TYPO3\CMS\Core;
 
 /**
  * VarDumpHelper
@@ -32,17 +32,17 @@ use TYPO3\CMS\Core\Utility\DebugUtility;
  * @author Elias Häußler <e.haeussler@familie-redlich.de>
  * @license GPL-2.0-or-later
  */
-class VarDumpHelper implements HelperInterface
+final readonly class VarDumpHelper implements HelperInterface
 {
     /**
      * @param array<string|int, mixed> $context
      */
-    #[AsHelper('varDump')]
+    #[Attribute\AsHelper('varDump')]
     public static function evaluate(array $context): string
     {
         \ob_start();
 
-        DebugUtility::debug($context['_this']);
+        Core\Utility\DebugUtility::debug($context['_this']);
 
         return (string)\ob_get_clean();
     }

--- a/Classes/Renderer/Template/TemplatePaths.php
+++ b/Classes/Renderer/Template/TemplatePaths.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace Fr\Typo3Handlebars\Renderer\Template;
 
 use Fr\Typo3Handlebars\Configuration\Extension;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
 
@@ -51,6 +52,10 @@ class TemplatePaths
      */
     public function __construct(
         protected readonly ConfigurationManagerInterface $configurationManager,
+        #[Autowire([
+            self::TEMPLATES => '%handlebars.template_root_paths%',
+            self::PARTIALS => '%handlebars.partial_root_paths%',
+        ])]
         protected readonly array $viewConfiguration = [],
         protected readonly string $type = self::TEMPLATES,
     ) {}

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -38,13 +38,6 @@ services:
     arguments:
       $type: 'partial_root_paths'
 
-  # Handlebars Helper
-  Fr\Typo3Handlebars\Renderer\Helper\VarDumpHelper:
-    tags:
-      - name: handlebars.helper
-        identifier: 'varDump'
-        method: 'evaluate'
-
   # Cache
   cache.handlebars:
     class: TYPO3\CMS\Core\Cache\Frontend\FrontendInterface

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -9,18 +9,12 @@ services:
     exclude:
       - '../Classes/DependencyInjection/*'
 
-  # Renderer
-  handlebars.renderer:
-    class: 'Fr\Typo3Handlebars\Renderer\HandlebarsRenderer'
-    arguments:
-      $templateResolver: '@handlebars.template_resolver'
-      $partialResolver: '@handlebars.partial_resolver'
-      $cache: '@handlebars.cache'
-      $defaultData: '%handlebars.default_data%'
-    tags: ['handlebars.renderer']
-
+  Fr\Typo3Handlebars\Cache\CacheInterface:
+    alias: 'handlebars.cache'
   Fr\Typo3Handlebars\Renderer\RendererInterface:
     alias: 'handlebars.renderer'
+  Fr\Typo3Handlebars\Renderer\Template\TemplateResolverInterface:
+    alias: 'handlebars.template_resolver'
 
   # Template
   handlebars.template_resolver:
@@ -33,15 +27,8 @@ services:
     arguments:
       $templateRootPaths: '@handlebars.template_paths.partial_root_paths'
 
-  Fr\Typo3Handlebars\Renderer\Template\TemplateResolverInterface:
-    alias: 'handlebars.template_resolver'
-
   handlebars.template_paths:
     class: 'Fr\Typo3Handlebars\Renderer\Template\TemplatePaths'
-    arguments:
-      $viewConfiguration:
-        template_root_paths: '%handlebars.template_root_paths%'
-        partial_root_paths: '%handlebars.partial_root_paths%'
   handlebars.template_paths.template_root_paths:
     parent: 'handlebars.template_paths'
     arguments:
@@ -51,10 +38,6 @@ services:
     arguments:
       $type: 'partial_root_paths'
 
-  # Data processor
-  Fr\Typo3Handlebars\DataProcessing\SimpleProcessor:
-    public: true
-
   # Handlebars Helper
   Fr\Typo3Handlebars\Renderer\Helper\VarDumpHelper:
     tags:
@@ -63,22 +46,10 @@ services:
         method: 'evaluate'
 
   # Cache
-  handlebars.cache:
-    class: 'Fr\Typo3Handlebars\Cache\HandlebarsCache'
-    arguments:
-      $cache: '@cache.handlebars'
-
-  Fr\Typo3Handlebars\Cache\CacheInterface:
-    alias: 'handlebars.cache'
-
   cache.handlebars:
     class: TYPO3\CMS\Core\Cache\Frontend\FrontendInterface
     factory: ['@TYPO3\CMS\Core\Cache\CacheManager', 'getCache']
     arguments: ['handlebars']
-
-  # Compatibility
-  Fr\Typo3Handlebars\Compatibility\View\HandlebarsViewResolver:
-    public: true
 
 handlebars:
   default_data: []

--- a/Tests/Functional/Fixtures/test_extension/Classes/JsonHelper.php
+++ b/Tests/Functional/Fixtures/test_extension/Classes/JsonHelper.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace Fr\Typo3Handlebars\TestExtension;
 
+use Fr\Typo3Handlebars\Attribute;
 use Fr\Typo3Handlebars\Renderer;
 use LightnCandy\SafeString;
 
@@ -37,6 +38,7 @@ final class JsonHelper implements Renderer\Helper\HelperInterface
     /**
      * @param array<string, mixed> $context
      */
+    #[Attribute\AsHelper('jsonEncode')]
     public function encode(array $context): SafeString
     {
         return new SafeString(json_encode($context['_this'], JSON_THROW_ON_ERROR));

--- a/Tests/Functional/Fixtures/test_extension/Configuration/Services.yaml
+++ b/Tests/Functional/Fixtures/test_extension/Configuration/Services.yaml
@@ -1,0 +1,7 @@
+services:
+  _defaults:
+    autowire: true
+    autoconfigure: true
+
+  Fr\Typo3Handlebars\TestExtension\:
+    resource: '../Classes/*'

--- a/Tests/Unit/DependencyInjection/FeatureRegistrationPassTest.php
+++ b/Tests/Unit/DependencyInjection/FeatureRegistrationPassTest.php
@@ -26,6 +26,7 @@ namespace Fr\Typo3Handlebars\Tests\Unit\DependencyInjection;
 use Fr\Typo3Handlebars as Src;
 use Fr\Typo3Handlebars\Tests;
 use PHPUnit\Framework;
+use Psr\Container;
 use Psr\Log;
 use Symfony\Component\Config;
 use Symfony\Component\DependencyInjection;
@@ -135,6 +136,9 @@ final class FeatureRegistrationPassTest extends TestingFramework\Core\Unit\UnitT
         $container->register(Core\TypoScript\TypoScriptService::class);
         $container->register(Frontend\ContentObject\ContentObjectRenderer::class);
         $container->register(Log\LoggerInterface::class, Log\NullLogger::class);
+
+        // Aliases
+        $container->setAlias(Container\ContainerInterface::class, 'service_container');
 
         // Provide dummy extension configuration class
         $dummyExtensionConfiguration = new Tests\Unit\Fixtures\Classes\DummyExtensionConfiguration($this->activatedFeatures);


### PR DESCRIPTION
This PR introduces a new `#[AsHelper]` attribute. It can be used for auto-registration of Handlebars helpers. In addition, existing DI configuration is migrated to attributes where applicable.