### PR TITLE
[!!!][FEATURE] Require `render` method with helper context in helpers

### DIFF
--- a/Classes/Renderer/Component/Layout/HandlebarsLayout.php
+++ b/Classes/Renderer/Component/Layout/HandlebarsLayout.php
@@ -34,18 +34,21 @@ class HandlebarsLayout
     protected bool $parsed = false;
 
     /**
+     * @var array<string, list<HandlebarsLayoutAction>>
+     */
+    protected array $actions = [];
+
+    /**
      * @param callable $parseFunction
-     * @param array<string, HandlebarsLayoutAction[]> $actions
      */
     public function __construct(
         protected $parseFunction,
-        protected array $actions = [],
     ) {}
 
     public function parse(): void
     {
-        ($this->parseFunction)();
         $this->parsed = true;
+        ($this->parseFunction)();
     }
 
     public function addAction(string $name, HandlebarsLayoutAction $action): void
@@ -57,7 +60,7 @@ class HandlebarsLayout
     }
 
     /**
-     * @return array<string, HandlebarsLayoutAction[]>|HandlebarsLayoutAction[]
+     * @return ($name is null ? array<string, HandlebarsLayoutAction[]> : HandlebarsLayoutAction[])
      */
     public function getActions(string $name = null): array
     {
@@ -76,11 +79,5 @@ class HandlebarsLayout
     public function isParsed(): bool
     {
         return $this->parsed;
-    }
-
-    public function setParsed(bool $parsed): self
-    {
-        $this->parsed = $parsed;
-        return $this;
     }
 }

--- a/Classes/Renderer/Component/Layout/HandlebarsLayoutAction.php
+++ b/Classes/Renderer/Component/Layout/HandlebarsLayoutAction.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace Fr\Typo3Handlebars\Renderer\Component\Layout;
 
 use Fr\Typo3Handlebars\Exception;
+use Fr\Typo3Handlebars\Renderer;
 
 /**
  * HandlebarsLayoutAction
@@ -40,13 +41,10 @@ class HandlebarsLayoutAction
     protected readonly string $mode;
 
     /**
-     * @param array<string, mixed> $data
-     * @param callable $renderFunction
      * @throws Exception\UnsupportedTypeException
      */
     public function __construct(
-        protected readonly array $data,
-        protected $renderFunction,
+        protected readonly Renderer\Helper\Context\HelperContext $context,
         string $mode = self::REPLACE,
     ) {
         $this->mode = strtolower($mode);
@@ -60,7 +58,7 @@ class HandlebarsLayoutAction
      */
     public function render(string $value): string
     {
-        $renderResult = ($this->renderFunction)($this->data);
+        $renderResult = $this->context->renderChildren($this->context->renderingContext);
 
         return match ($this->mode) {
             self::APPEND => $value . $renderResult,

--- a/Classes/Renderer/Helper/BlockHelper.php
+++ b/Classes/Renderer/Helper/BlockHelper.php
@@ -34,18 +34,18 @@ use Fr\Typo3Handlebars\Renderer;
  * @license GPL-2.0-or-later
  * @see https://github.com/shannonmoeller/handlebars-layouts#block-name
  */
+#[Attribute\AsHelper('block')]
 final readonly class BlockHelper implements HelperInterface
 {
     /**
-     * @param array<string, mixed> $options
      * @throws Exception\UnsupportedTypeException
      */
-    #[Attribute\AsHelper('block')]
-    public function evaluate(string $name, array $options): string
+    public function render(Context\HelperContext $context): string
     {
-        $data = $options['_this'];
-        $actions = $data['_layoutActions'] ?? [];
-        $stack = $data['_layoutStack'] ?? [];
+        $name = $context[0];
+        $renderingContext = $context->renderingContext;
+        $actions = $renderingContext['_layoutActions'] ?? [];
+        $stack = $renderingContext['_layoutStack'] ?? [];
 
         // Parse layouts and fetch all parsed layout actions for the requested block
         while (!empty($stack)) {
@@ -58,12 +58,10 @@ final readonly class BlockHelper implements HelperInterface
         }
 
         // Walk through layout actions and apply them to the rendered block
-        $fn = $options['fn'] ?? static fn() => '';
-
         return array_reduce(
             $actions,
             static fn(string $value, Renderer\Component\Layout\HandlebarsLayoutAction $action): string => $action->render($value),
-            $fn($data),
+            $context->renderChildren($renderingContext) ?? '',
         );
     }
 }

--- a/Classes/Renderer/Helper/Context/HelperContext.php
+++ b/Classes/Renderer/Helper/Context/HelperContext.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "handlebars".
+ *
+ * Copyright (C) 2024 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace Fr\Typo3Handlebars\Renderer\Helper\Context;
+
+/**
+ * HelperContext
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-2.0-or-later
+ *
+ * @implements \ArrayAccess<int|string, mixed>
+ */
+final class HelperContext implements \ArrayAccess
+{
+    /**
+     * @param list<mixed> $arguments
+     * @param array<string, mixed> $hash
+     * @param array<string, mixed> $renderingContext
+     * @param array<'root'|int, array<string, mixed>> $data
+     * @param callable|null $childrenClosure
+     * @param callable|null $inverseClosure
+     */
+    public function __construct(
+        public readonly array $arguments, // 1...n-1
+        public readonly array $hash, // n['hash']
+        public readonly RenderingContextStack $contextStack, // n['contexts']
+        public array &$renderingContext, // n['_this']
+        public array &$data, // n['data'] => 'root', ...
+        private $childrenClosure = null, // n['fn']
+        private $inverseClosure = null, // n['inverse']
+    ) {}
+
+    /**
+     * @param list<mixed> $options
+     */
+    public static function fromRuntimeCall(array &$options): self
+    {
+        $context = array_pop($options);
+
+        $arguments = $options;
+        $hash = $context['hash'];
+        $contextStack = RenderingContextStack::fromRuntimeCall($context['contexts']);
+        $renderingContext = &$context['_this'];
+        $data = &$context['data'];
+        $childrenClosure = $context['fn'] ?? null;
+        $inverseClosure = $context['inverse'] ?? null;
+
+        return new self(
+            $arguments,
+            $hash,
+            $contextStack,
+            $renderingContext,
+            $data,
+            $childrenClosure,
+            $inverseClosure,
+        );
+    }
+
+    public function isBlockHelper(): bool
+    {
+        return $this->childrenClosure !== null;
+    }
+
+    public function renderChildren(): mixed
+    {
+        if ($this->childrenClosure === null) {
+            return null;
+        }
+
+        return ($this->childrenClosure)(...\func_get_args());
+    }
+
+    public function renderInverse(): mixed
+    {
+        if ($this->inverseClosure === null) {
+            return null;
+        }
+
+        return ($this->inverseClosure)(...\func_get_args());
+    }
+
+    public function offsetExists(mixed $offset): bool
+    {
+        if (is_numeric($offset)) {
+            return isset($this->arguments[$offset]);
+        }
+
+        return isset($this->hash[$offset]);
+    }
+
+    public function offsetGet(mixed $offset): mixed
+    {
+        if (is_numeric($offset)) {
+            return $this->arguments[$offset]
+                ?? throw new \OutOfBoundsException('Argument "' . $offset . '" does not exist.', 1736235839);
+        }
+
+        return $this->hash[$offset]
+            ?? throw new \OutOfBoundsException('Hash "' . $offset . '" does not exist.', 1736235851);
+    }
+
+    public function offsetSet(mixed $offset, mixed $value): never
+    {
+        throw new \LogicException('Helper context is locked and cannot be modified.', 1734434746);
+    }
+
+    public function offsetUnset(mixed $offset): never
+    {
+        throw new \LogicException('Helper context is locked and cannot be modified.', 1734434780);
+    }
+}

--- a/Classes/Renderer/Helper/Context/RenderingContextStack.php
+++ b/Classes/Renderer/Helper/Context/RenderingContextStack.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "handlebars".
+ *
+ * Copyright (C) 2024 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace Fr\Typo3Handlebars\Renderer\Helper\Context;
+
+/**
+ * RenderingContextStack
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-2.0-or-later
+ *
+ * @implements \IteratorAggregate<int, array<string, mixed>>
+ */
+final class RenderingContextStack implements \IteratorAggregate
+{
+    /**
+     * @param list<array<string, mixed>> $stack
+     */
+    public function __construct(
+        private array &$stack,
+    ) {
+        $this->reset();
+    }
+
+    /**
+     * @param array{null}|list<array<string, mixed>> $contexts
+     */
+    public static function fromRuntimeCall(array &$contexts): self
+    {
+        if ($contexts === [null]) {
+            $stack = [];
+        } else {
+            $stack = &$contexts;
+        }
+
+        return new self($stack);
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     *
+     * @impure
+     */
+    public function pop(): ?array
+    {
+        $current = \current($this->stack);
+
+        // Go to previous context in stack
+        prev($this->stack);
+
+        if ($current === false || !is_array($current)) {
+            return null;
+        }
+
+        return $current;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function first(): ?array
+    {
+        $firstKey = \array_key_first($this->stack);
+
+        if ($firstKey !== null) {
+            return $this->stack[$firstKey];
+        }
+
+        return null;
+    }
+
+    /**
+     * @impure
+     */
+    public function reset(): void
+    {
+        end($this->stack);
+    }
+
+    /**
+     * @impure
+     */
+    public function isEmpty(): bool
+    {
+        return \current($this->stack) === false;
+    }
+
+    /**
+     * @return \ArrayIterator<int, array<string, mixed>>
+     */
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator(array_reverse($this->stack));
+    }
+}

--- a/Classes/Renderer/Helper/HelperInterface.php
+++ b/Classes/Renderer/Helper/HelperInterface.php
@@ -29,4 +29,7 @@ namespace Fr\Typo3Handlebars\Renderer\Helper;
  * @author Elias Häußler <e.haeussler@familie-redlich.de>
  * @license GPL-2.0-or-later
  */
-interface HelperInterface {}
+interface HelperInterface
+{
+    public function render(Context\HelperContext $context): mixed;
+}

--- a/Classes/Renderer/Helper/VarDumpHelper.php
+++ b/Classes/Renderer/Helper/VarDumpHelper.php
@@ -32,17 +32,14 @@ use TYPO3\CMS\Core;
  * @author Elias Häußler <e.haeussler@familie-redlich.de>
  * @license GPL-2.0-or-later
  */
+#[Attribute\AsHelper('varDump')]
 final readonly class VarDumpHelper implements HelperInterface
 {
-    /**
-     * @param array<string|int, mixed> $context
-     */
-    #[Attribute\AsHelper('varDump')]
-    public static function evaluate(array $context): string
+    public function render(Context\HelperContext $context): string
     {
         \ob_start();
 
-        Core\Utility\DebugUtility::debug($context['_this']);
+        Core\Utility\DebugUtility::debug($context->renderingContext);
 
         return (string)\ob_get_clean();
     }

--- a/Configuration/Services.php
+++ b/Configuration/Services.php
@@ -25,6 +25,7 @@ namespace Fr\Typo3Handlebars\DependencyInjection;
 
 use Fr\Typo3Handlebars\Attribute\AsHelper;
 use Fr\Typo3Handlebars\DependencyInjection\Extension\HandlebarsExtension;
+use Fr\Typo3Handlebars\Renderer\Helper\HelperInterface;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
@@ -42,7 +43,15 @@ return static function (ContainerConfigurator $containerConfigurator, ContainerB
                 AsHelper::TAG_NAME,
                 [
                     'identifier' => $attribute->identifier,
-                    'method' => $attribute->method ?? ($reflector instanceof \ReflectionMethod ? $reflector->getName() : '__invoke'),
+                    'method' => $attribute->method ?? (
+                        $reflector instanceof \ReflectionMethod
+                        ? $reflector->getName()
+                        : (
+                            $reflector instanceof \ReflectionClass && $reflector->implementsInterface(HelperInterface::class)
+                            ? 'render'
+                            : '__invoke'
+                        )
+                    ),
                 ],
             );
         },

--- a/Tests/Functional/Fixtures/test_extension/Classes/JsonHelper.php
+++ b/Tests/Functional/Fixtures/test_extension/Classes/JsonHelper.php
@@ -33,14 +33,11 @@ use LightnCandy\SafeString;
  * @author Elias Häußler <e.haeussler@familie-redlich.de>
  * @license GPL-2.0-or-later
  */
+#[Attribute\AsHelper('jsonEncode')]
 final class JsonHelper implements Renderer\Helper\HelperInterface
 {
-    /**
-     * @param array<string, mixed> $context
-     */
-    #[Attribute\AsHelper('jsonEncode')]
-    public function encode(array $context): SafeString
+    public function render(Renderer\Helper\Context\HelperContext $context): SafeString
     {
-        return new SafeString(json_encode($context['_this'], JSON_THROW_ON_ERROR));
+        return new SafeString(json_encode($context->renderingContext, JSON_THROW_ON_ERROR));
     }
 }

--- a/Tests/Functional/Fixtures/test_extension/Resources/Templates/main-layout-extended-with-fifth-block.hbs
+++ b/Tests/Functional/Fixtures/test_extension/Resources/Templates/main-layout-extended-with-fifth-block.hbs
@@ -1,0 +1,10 @@
+{{#extend templateName}}
+    {{#content "fourth" mode="append"}}
+
+        {{#block "fifth"}}
+            this is the fifth block:
+
+            fifth block
+        {{/block}}
+    {{/content}}
+{{/extend}}

--- a/Tests/Functional/Fixtures/test_extension/Resources/Templates/main-layout-extended-with-fifth-content.hbs
+++ b/Tests/Functional/Fixtures/test_extension/Resources/Templates/main-layout-extended-with-fifth-content.hbs
@@ -1,0 +1,5 @@
+{{#extend "@main-layout-extended-with-fifth-block"}}
+    {{#content "fifth" mode="append"}}
+        injected
+    {{/content}}
+{{/extend}}

--- a/Tests/Functional/Renderer/Helper/BlockHelperTest.php
+++ b/Tests/Functional/Renderer/Helper/BlockHelperTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of the TYPO3 CMS extension "handlebars".
  *
- * Copyright (C) 2024 Elias Häußler <e.haeussler@familie-redlich.de>
+ * Copyright (C) 2025 Elias Häußler <e.haeussler@familie-redlich.de>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -31,13 +31,13 @@ use Symfony\Component\EventDispatcher;
 use TYPO3\TestingFramework;
 
 /**
- * ContentHelperTest
+ * BlockHelperTest
  *
  * @author Elias Häußler <e.haeussler@familie-redlich.de>
  * @license GPL-2.0-or-later
  */
-#[Framework\Attributes\CoversClass(Src\Renderer\Helper\ContentHelper::class)]
-final class ContentHelperTest extends TestingFramework\Core\Functional\FunctionalTestCase
+#[Framework\Attributes\CoversClass(Src\Renderer\Helper\BlockHelper::class)]
+final class BlockHelperTest extends TestingFramework\Core\Functional\FunctionalTestCase
 {
     use Tests\HandlebarsTemplateResolverTrait;
 
@@ -69,29 +69,25 @@ final class ContentHelperTest extends TestingFramework\Core\Functional\Functiona
     }
 
     #[Framework\Attributes\Test]
-    public function helperCanBeCalledFromExtendedLayout(): void
+    public function helperCanBeCalledFromMainLayout(): void
     {
-        $actual = trim($this->renderer->render('@main-layout-extended', [
-            'templateName' => '@main-layout',
-        ]));
+        $actual = trim($this->renderer->render('@main-layout'));
         $expected = implode(PHP_EOL, [
             'this is the main block:',
             '',
             '[ ]+main block',
-            '[ ]+injected',
             '',
             'this is the second block:',
             '',
-            '[ ]+injected',
             '[ ]+second block',
             '',
             'this is the third block:',
             '',
-            '[ ]+injected',
+            '[ ]+third block',
             '',
             'this is the fourth block:',
             '',
-            '[ ]+injected',
+            '[ ]+fourth block',
             '',
             'this is the end. bye bye',
         ]);
@@ -100,38 +96,36 @@ final class ContentHelperTest extends TestingFramework\Core\Functional\Functiona
     }
 
     #[Framework\Attributes\Test]
-    public function helperCannotBeCalledOutsideOfExtendedLayout(): void
+    public function helperCanBeCalledFromExtendedLayout(): void
     {
-        $this->renderer->render('@main-layout-content-only');
-
-        self::assertTrue(
-            $this->logger->hasError([
-                'message' => 'Handlebars layout helper "content" can only be used within an "extend" helper block!',
-                'context' => [
-                    'name' => 'main',
-                ],
-            ])
-        );
-    }
-
-    #[Framework\Attributes\Test]
-    #[Framework\Attributes\DataProvider('helperCanBeCalledToConditionallyRenderBlocksDataProvider')]
-    public function helperCanBeCalledToConditionallyRenderBlocks(bool $renderSecondBlock, string $expected): void
-    {
-        $actual = trim($this->renderer->render('@main-layout-extended-with-conditional-contents', [
-            'templateName' => '@main-layout-conditional-block',
-            'renderSecondBlock' => $renderSecondBlock,
+        $actual = trim($this->renderer->render('@main-layout-extended-with-fifth-content', [
+            'templateName' => '@main-layout',
         ]));
+        $expected = implode(PHP_EOL, [
+            'this is the main block:',
+            '',
+            '[ ]+main block',
+            '',
+            'this is the second block:',
+            '',
+            '[ ]+second block',
+            '',
+            'this is the third block:',
+            '',
+            '[ ]+third block',
+            '',
+            'this is the fourth block:',
+            '',
+            '[ ]+fourth block',
+            '',
+            '[ ]+this is the fifth block:',
+            '',
+            '[ ]+fifth block',
+            '[ ]+injected',
+            '',
+            'this is the end. bye bye',
+        ]);
 
         self::assertMatchesRegularExpression('/^' . $expected . '$/', $actual);
-    }
-
-    /**
-     * @return \Generator<string, array{bool, string}>
-     */
-    public static function helperCanBeCalledToConditionallyRenderBlocksDataProvider(): \Generator
-    {
-        yield 'without second block' => [false, ''];
-        yield 'with second block' => [true, 'main block\n+[ ]+second block'];
     }
 }

--- a/Tests/Functional/Renderer/Helper/ExtendHelperTest.php
+++ b/Tests/Functional/Renderer/Helper/ExtendHelperTest.php
@@ -62,8 +62,8 @@ final class ExtendHelperTest extends TestingFramework\Core\Functional\Functional
             new Log\NullLogger(),
             $this->templateResolver,
         );
-        $this->renderer->registerHelper('extend', [new Src\Renderer\Helper\ExtendHelper($this->renderer), 'evaluate']);
-        $this->renderer->registerHelper('jsonEncode', [new TestExtension\JsonHelper(), 'encode']);
+        $this->renderer->registerHelper('extend', new Src\Renderer\Helper\ExtendHelper($this->renderer));
+        $this->renderer->registerHelper('jsonEncode', new TestExtension\JsonHelper());
     }
 
     #[Framework\Attributes\Test]

--- a/Tests/Functional/Renderer/Helper/RenderHelperTest.php
+++ b/Tests/Functional/Renderer/Helper/RenderHelperTest.php
@@ -75,7 +75,7 @@ final class RenderHelperTest extends TestingFramework\Core\Functional\Functional
             $this->contentObjectRenderer,
         );
 
-        $this->renderer->registerHelper('render', [$subject, 'evaluate']);
+        $this->renderer->registerHelper('render', $subject);
     }
 
     #[Framework\Attributes\Test]

--- a/Tests/Unit/DataProcessing/SimpleProcessorTest.php
+++ b/Tests/Unit/DataProcessing/SimpleProcessorTest.php
@@ -88,7 +88,7 @@ final class SimpleProcessorTest extends TestingFramework\Core\Unit\UnitTestCase
     #[Framework\Attributes\Test]
     public function processReturnsRenderedTemplate(): void
     {
-        $this->renderer->registerHelper('varDump', Src\Renderer\Helper\VarDumpHelper::class . '::evaluate');
+        $this->renderer->registerHelper('varDump', Src\Renderer\Helper\VarDumpHelper::class);
 
         $this->contentObjectRendererMock->data = [
             'uid' => 1,

--- a/Tests/Unit/Fixtures/Classes/Renderer/Helper/DummyHelper.php
+++ b/Tests/Unit/Fixtures/Classes/Renderer/Helper/DummyHelper.php
@@ -34,6 +34,11 @@ use Fr\Typo3Handlebars\Renderer;
  */
 final readonly class DummyHelper implements Renderer\Helper\HelperInterface
 {
+    public function render(Renderer\Helper\Context\HelperContext $context): string
+    {
+        return 'foo';
+    }
+
     public function __invoke(): string
     {
         return 'foo';

--- a/Tests/Unit/Renderer/Component/Layout/HandlebarsLayoutActionTest.php
+++ b/Tests/Unit/Renderer/Component/Layout/HandlebarsLayoutActionTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "handlebars".
+ *
+ * Copyright (C) 2025 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace Fr\Typo3Handlebars\Tests\Unit\Renderer\Component\Layout;
+
+use Fr\Typo3Handlebars as Src;
+use PHPUnit\Framework;
+use TYPO3\TestingFramework;
+
+/**
+ * HandlebarsLayoutActionTest
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-2.0-or-later
+ */
+#[Framework\Attributes\CoversClass(Src\Renderer\Component\Layout\HandlebarsLayoutAction::class)]
+final class HandlebarsLayoutActionTest extends TestingFramework\Core\Unit\UnitTestCase
+{
+    private Src\Renderer\Helper\Context\HelperContext $context;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $renderingContext = [];
+        $data = [];
+        $stack = [];
+
+        $this->context = new Src\Renderer\Helper\Context\HelperContext(
+            [],
+            [],
+            new Src\Renderer\Helper\Context\RenderingContextStack($stack),
+            $renderingContext,
+            $data,
+            static fn() => 'baz'
+        );
+    }
+
+    /**
+     * @param Src\Renderer\Component\Layout\HandlebarsLayoutAction::* $mode
+     */
+    #[Framework\Attributes\Test]
+    #[Framework\Attributes\DataProvider('renderReturnsProcessedValueDataProvider')]
+    public function renderReturnsProcessedValue(string $mode, string $expected): void
+    {
+        $subject = new Src\Renderer\Component\Layout\HandlebarsLayoutAction($this->context, $mode);
+
+        self::assertSame($expected, $subject->render('foo'));
+    }
+
+    /**
+     * @return \Generator<string, array{Src\Renderer\Component\Layout\HandlebarsLayoutAction::*, string}>
+     */
+    public static function renderReturnsProcessedValueDataProvider(): \Generator
+    {
+        yield 'replace' => [Src\Renderer\Component\Layout\HandlebarsLayoutAction::REPLACE, 'baz'];
+        yield 'append' => [Src\Renderer\Component\Layout\HandlebarsLayoutAction::APPEND, 'foobaz'];
+        yield 'prepend' => [Src\Renderer\Component\Layout\HandlebarsLayoutAction::PREPEND, 'bazfoo'];
+    }
+}

--- a/Tests/Unit/Renderer/Component/Layout/HandlebarsLayoutTest.php
+++ b/Tests/Unit/Renderer/Component/Layout/HandlebarsLayoutTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "handlebars".
+ *
+ * Copyright (C) 2025 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace Fr\Typo3Handlebars\Tests\Unit\Renderer\Component\Layout;
+
+use Fr\Typo3Handlebars as Src;
+use PHPUnit\Framework;
+use TYPO3\TestingFramework;
+
+/**
+ * HandlebarsLayoutTest
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-2.0-or-later
+ */
+#[Framework\Attributes\CoversClass(Src\Renderer\Component\Layout\HandlebarsLayout::class)]
+final class HandlebarsLayoutTest extends TestingFramework\Core\Unit\UnitTestCase
+{
+    private Src\Renderer\Component\Layout\HandlebarsLayout $subject;
+    private Src\Renderer\Component\Layout\HandlebarsLayoutAction $action;
+
+    private bool $parseFunctionInvoked = false;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $stack = [];
+        $renderingContext = [];
+        $data = [];
+
+        $this->subject = new Src\Renderer\Component\Layout\HandlebarsLayout(
+            fn() => $this->parseFunctionInvoked = true,
+        );
+        $this->action = new Src\Renderer\Component\Layout\HandlebarsLayoutAction(
+            new Src\Renderer\Helper\Context\HelperContext(
+                [],
+                [],
+                new Src\Renderer\Helper\Context\RenderingContextStack($stack),
+                $renderingContext,
+                $data,
+            ),
+        );
+    }
+
+    #[Framework\Attributes\Test]
+    public function parseInvokesParseFunctionAndMarksComponentAsParsed(): void
+    {
+        self::assertFalse($this->parseFunctionInvoked);
+        self::assertFalse($this->subject->isParsed());
+
+        $this->subject->parse();
+
+        self::assertTrue($this->parseFunctionInvoked);
+        self::assertTrue($this->subject->isParsed());
+    }
+
+    #[Framework\Attributes\Test]
+    public function addActionRegistersGivenAction(): void
+    {
+        self::assertSame([], $this->subject->getActions());
+
+        $this->subject->addAction('foo', $this->action);
+
+        self::assertSame(
+            [
+                'foo' => [
+                    $this->action,
+                ],
+            ],
+            $this->subject->getActions(),
+        );
+    }
+
+    #[Framework\Attributes\Test]
+    public function getActionsReturnsAllRegisteredActions(): void
+    {
+        $this->subject->addAction('foo', $this->action);
+        $this->subject->addAction('baz', $this->action);
+
+        self::assertSame(['foo', 'baz'], \array_keys($this->subject->getActions()));
+    }
+
+    #[Framework\Attributes\Test]
+    public function getActionsReturnsRegisteredActionsByGivenName(): void
+    {
+        $this->subject->addAction('foo', $this->action);
+        $this->subject->addAction('baz', $this->action);
+
+        self::assertSame([$this->action], $this->subject->getActions('foo'));
+        self::assertSame([], $this->subject->getActions('missing'));
+    }
+
+    #[Framework\Attributes\Test]
+    public function hasActionReturnsTrueIfActionOfGivenNameWasRegistered(): void
+    {
+        self::assertFalse($this->subject->hasAction('foo'));
+
+        $this->subject->addAction('foo', $this->action);
+
+        self::assertTrue($this->subject->hasAction('foo'));
+    }
+}

--- a/Tests/Unit/Renderer/HandlebarsRendererTest.php
+++ b/Tests/Unit/Renderer/HandlebarsRendererTest.php
@@ -106,7 +106,7 @@ final class HandlebarsRendererTest extends TestingFramework\Core\Unit\UnitTestCa
     #[Framework\Attributes\Test]
     public function renderMergesDefaultDataWithGivenData(): void
     {
-        $this->subject->registerHelper('varDump', Src\Renderer\Helper\VarDumpHelper::class . '::evaluate');
+        $this->subject->registerHelper('varDump', Src\Renderer\Helper\VarDumpHelper::class);
         $this->subject->setDefaultData([
             'foo' => 'baz',
         ]);

--- a/Tests/Unit/Renderer/Helper/Context/HelperContextTest.php
+++ b/Tests/Unit/Renderer/Helper/Context/HelperContextTest.php
@@ -1,0 +1,302 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "handlebars".
+ *
+ * Copyright (C) 2025 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace Fr\Typo3Handlebars\Tests\Unit\Renderer\Helper\Context;
+
+use Fr\Typo3Handlebars as Src;
+use PHPUnit\Framework;
+use TYPO3\TestingFramework;
+
+/**
+ * HelperContextTest
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-2.0-or-later
+ */
+#[Framework\Attributes\CoversClass(Src\Renderer\Helper\Context\HelperContext::class)]
+final class HelperContextTest extends TestingFramework\Core\Unit\UnitTestCase
+{
+    private Src\Renderer\Helper\Context\HelperContext $subject;
+
+    /**
+     * @var list<array<string, string>>
+     */
+    private array $stack = [
+        ['foo' => 'baz'],
+        ['baz' => 'foo'],
+    ];
+
+    /**
+     * @var array<string, string>
+     */
+    private array $renderingContext = [
+        'foo' => 'baz',
+    ];
+
+    /**
+     * @var array<'root'|int, array<string, string>>
+     */
+    private array $data = [
+        'root' => [
+            'foo' => 'baz',
+        ],
+        [
+            'foo' => 'baz',
+        ],
+    ];
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->subject = new Src\Renderer\Helper\Context\HelperContext(
+            [
+                'foo',
+                'baz',
+            ],
+            [
+                'foo' => 'baz',
+            ],
+            new Src\Renderer\Helper\Context\RenderingContextStack($this->stack),
+            $this->renderingContext,
+            $this->data,
+            static fn() => 'foo',
+            static fn() => 'baz',
+        );
+    }
+
+    #[Framework\Attributes\Test]
+    public function fromRuntimeCallReturnsConstructedContext(): void
+    {
+        $options = $this->getRuntimeOptions();
+
+        $actual = Src\Renderer\Helper\Context\HelperContext::fromRuntimeCall($options);
+
+        self::assertEquals($this->subject, $actual);
+    }
+
+    #[Framework\Attributes\Test]
+    public function fromRuntimeCallPassesContextStackAsReference(): void
+    {
+        $options = $this->getRuntimeOptions();
+
+        $actual = Src\Renderer\Helper\Context\HelperContext::fromRuntimeCall($options);
+
+        $this->stack[] = ['boo' => 'faz'];
+
+        self::assertSame(
+            [
+                ['boo' => 'faz'],
+                ['baz' => 'foo'],
+                ['foo' => 'baz'],
+            ],
+            \iterator_to_array($actual->contextStack),
+        );
+    }
+
+    #[Framework\Attributes\Test]
+    public function fromRuntimeCallPassesRenderingContextAsReference(): void
+    {
+        $options = $this->getRuntimeOptions();
+
+        $actual = Src\Renderer\Helper\Context\HelperContext::fromRuntimeCall($options);
+
+        $this->renderingContext['baz'] = 'foo';
+
+        self::assertSame(
+            [
+                'foo' => 'baz',
+                'baz' => 'foo',
+            ],
+            $actual->renderingContext,
+        );
+    }
+
+    #[Framework\Attributes\Test]
+    public function fromRuntimeCallPassesDataAsReference(): void
+    {
+        $options = $this->getRuntimeOptions();
+
+        $actual = Src\Renderer\Helper\Context\HelperContext::fromRuntimeCall($options);
+
+        $this->data[] = ['baz' => 'foo'];
+
+        self::assertSame(
+            [
+                'root' => [
+                    'foo' => 'baz',
+                ],
+                [
+                    'foo' => 'baz',
+                ],
+                [
+                    'baz' => 'foo',
+                ],
+            ],
+            $actual->data,
+        );
+    }
+
+    #[Framework\Attributes\Test]
+    public function isBlockHelperReturnsTrueIfChildrenClosureExists(): void
+    {
+        self::assertTrue($this->subject->isBlockHelper());
+
+        $options = $this->getRuntimeOptions(false);
+        $subject = Src\Renderer\Helper\Context\HelperContext::fromRuntimeCall($options);
+
+        self::assertFalse($subject->isBlockHelper());
+    }
+
+    #[Framework\Attributes\Test]
+    public function renderChildrenReturnsNullIfNoChildrenClosureExists(): void
+    {
+        $options = $this->getRuntimeOptions(false);
+        $subject = Src\Renderer\Helper\Context\HelperContext::fromRuntimeCall($options);
+
+        self::assertNull($subject->renderChildren());
+    }
+
+    #[Framework\Attributes\Test]
+    public function renderChildrenInvokesChildrenClosureWithGivenArguments(): void
+    {
+        $options = $this->getRuntimeOptions();
+        $subject = Src\Renderer\Helper\Context\HelperContext::fromRuntimeCall($options);
+
+        self::assertSame('fn: foo', $subject->renderChildren('foo'));
+    }
+
+    #[Framework\Attributes\Test]
+    public function renderInverseReturnsNullIfNoInverseClosureExists(): void
+    {
+        $options = $this->getRuntimeOptions(true, false);
+        $subject = Src\Renderer\Helper\Context\HelperContext::fromRuntimeCall($options);
+
+        self::assertNull($subject->renderInverse());
+    }
+
+    #[Framework\Attributes\Test]
+    public function renderInverseInvokesInverseClosureWithGivenArguments(): void
+    {
+        $options = $this->getRuntimeOptions();
+        $subject = Src\Renderer\Helper\Context\HelperContext::fromRuntimeCall($options);
+
+        self::assertSame('inverse: foo', $subject->renderInverse('foo'));
+    }
+
+    #[Framework\Attributes\Test]
+    public function objectCanBeAccessedAsReadOnlyArray(): void
+    {
+        // offsetExists
+        self::assertTrue(isset($this->subject[0]));
+        self::assertTrue(isset($this->subject[1]));
+        self::assertFalse(isset($this->subject[2]));
+        self::assertTrue(isset($this->subject['foo']));
+        self::assertFalse(isset($this->subject['baz']));
+
+        // offsetGet
+        self::assertSame('foo', $this->subject[0]);
+        self::assertSame('baz', $this->subject[1]);
+        self::assertSame('baz', $this->subject['foo']);
+    }
+
+    #[Framework\Attributes\Test]
+    public function offsetGetThrowsExceptionIfGivenArgumentDoesNotExist(): void
+    {
+        $this->expectExceptionObject(
+            new \OutOfBoundsException('Argument "99" does not exist.', 1736235839),
+        );
+
+        $x = $this->subject[99];
+    }
+
+    #[Framework\Attributes\Test]
+    public function offsetGetThrowsExceptionIfGivenHashDoesNotExist(): void
+    {
+        $this->expectExceptionObject(
+            new \OutOfBoundsException('Hash "missing" does not exist.', 1736235851),
+        );
+
+        $x = $this->subject['missing'];
+    }
+
+    #[Framework\Attributes\Test]
+    public function offsetSetThrowsLogicException(): void
+    {
+        $this->expectExceptionObject(
+            new \LogicException('Helper context is locked and cannot be modified.', 1734434746),
+        );
+
+        $this->subject['baz'] = 'foo';
+    }
+
+    #[Framework\Attributes\Test]
+    public function offsetUnsetThrowsLogicException(): void
+    {
+        $this->expectExceptionObject(
+            new \LogicException('Helper context is locked and cannot be modified.', 1734434780),
+        );
+
+        unset($this->subject['foo']);
+    }
+
+    /**
+     * @return array{
+     *     string,
+     *     string,
+     *     array{
+     *         hash: array<string, string>,
+     *         contexts: list<array<string, string>>,
+     *         _this: array<string, string>,
+     *         data: array<'root'|int, array<string, string>>,
+     *         fn?: callable(string): string,
+     *         inverse?: callable(string): string,
+     *     },
+     * }
+     */
+    private function getRuntimeOptions(bool $includeChildrenClosure = true, bool $includeInverseClosure = true): array
+    {
+        $options = [
+            'foo',
+            'baz',
+            [
+                'hash' => [
+                    'foo' => 'baz',
+                ],
+                'contexts' => &$this->stack,
+                '_this' => &$this->renderingContext,
+                'data' => &$this->data,
+            ],
+        ];
+
+        if ($includeChildrenClosure) {
+            $options[2]['fn'] = static fn(string $input) => 'fn: ' . $input;
+        }
+
+        if ($includeInverseClosure) {
+            $options[2]['inverse'] = static fn(string $input) => 'inverse: ' . $input;
+        }
+
+        return $options;
+    }
+}

--- a/Tests/Unit/Renderer/Helper/Context/RenderingContextStackTest.php
+++ b/Tests/Unit/Renderer/Helper/Context/RenderingContextStackTest.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "handlebars".
+ *
+ * Copyright (C) 2025 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace Fr\Typo3Handlebars\Tests\Unit\Renderer\Helper\Context;
+
+use Fr\Typo3Handlebars as Src;
+use PHPUnit\Framework;
+use TYPO3\TestingFramework;
+
+/**
+ * RenderingContextStackTest
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-2.0-or-later
+ */
+#[Framework\Attributes\CoversClass(Src\Renderer\Helper\Context\RenderingContextStack::class)]
+final class RenderingContextStackTest extends TestingFramework\Core\Unit\UnitTestCase
+{
+    private Src\Renderer\Helper\Context\RenderingContextStack $subject;
+
+    /**
+     * @var list<array<string, mixed>>
+     */
+    private array $stack = [
+        ['foo' => 'baz'],
+        ['baz' => 'foo'],
+    ];
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->subject = new Src\Renderer\Helper\Context\RenderingContextStack($this->stack);
+    }
+
+    #[Framework\Attributes\Test]
+    public function constructorStoresGivenStackByReference(): void
+    {
+        $this->stack[] = ['boo' => 'faz'];
+
+        $expected = [
+            ['boo' => 'faz'],
+            ['baz' => 'foo'],
+            ['foo' => 'baz'],
+        ];
+
+        self::assertSame($expected, \iterator_to_array($this->subject));
+    }
+
+    #[Framework\Attributes\Test]
+    public function constructorSetsArrayPointerToEndOfGivenStack(): void
+    {
+        $subject = new Src\Renderer\Helper\Context\RenderingContextStack($this->stack);
+
+        self::assertSame(['baz' => 'foo'], $subject->pop());
+    }
+
+    #[Framework\Attributes\Test]
+    public function fromRuntimeCallReturnsObjectWithEmptyStackIfGivenContextsAreEmpty(): void
+    {
+        // This is a "special" syntax from LightnCandy
+        $contexts = [null];
+
+        $subject = Src\Renderer\Helper\Context\RenderingContextStack::fromRuntimeCall($contexts);
+
+        self::assertSame([], \iterator_to_array($subject));
+    }
+
+    #[Framework\Attributes\Test]
+    public function fromRuntimeCallReturnsObjectWithGivenContextsByReference(): void
+    {
+        $subject = Src\Renderer\Helper\Context\RenderingContextStack::fromRuntimeCall($this->stack);
+
+        self::assertSame(
+            [
+                ['baz' => 'foo'],
+                ['foo' => 'baz'],
+            ],
+            \iterator_to_array($subject),
+        );
+
+        unset($this->stack[0], $this->stack[1]);
+
+        self::assertSame([], \iterator_to_array($subject));
+    }
+
+    #[Framework\Attributes\Test]
+    public function popReturnsCurrentContextAndSetsInternalArrayPointerToPreviousContextInStack(): void
+    {
+        self::assertSame(['baz' => 'foo'], $this->subject->pop());
+        self::assertSame(['foo' => 'baz'], $this->subject->pop());
+        self::assertTrue($this->subject->isEmpty());
+    }
+
+    #[Framework\Attributes\Test]
+    public function popReturnsNullIfStackIsEmpty(): void
+    {
+        $this->stack = [];
+
+        $subject = new Src\Renderer\Helper\Context\RenderingContextStack($this->stack);
+
+        self::assertNull($subject->pop());
+    }
+
+    #[Framework\Attributes\Test]
+    public function popReturnsNullIfStackIsProcessed(): void
+    {
+        $this->subject->pop();
+        $this->subject->pop();
+
+        self::assertNull($this->subject->pop());
+    }
+
+    #[Framework\Attributes\Test]
+    public function popReturnsNullIfContextIsInvalid(): void
+    {
+        $stack = ['foo'];
+        $subject = new Src\Renderer\Helper\Context\RenderingContextStack($stack);
+
+        self::assertNull($subject->pop());
+    }
+
+    #[Framework\Attributes\Test]
+    public function firstReturnsFirstElementInStack(): void
+    {
+        self::assertSame(['foo' => 'baz'], $this->subject->first());
+    }
+
+    #[Framework\Attributes\Test]
+    public function firstReturnsNullIfStackIsEmpty(): void
+    {
+        $stack = [];
+        $subject = new Src\Renderer\Helper\Context\RenderingContextStack($stack);
+
+        self::assertNull($subject->first());
+    }
+
+    #[Framework\Attributes\Test]
+    public function resetSetsInternalArrayPointerToEndOfStack(): void
+    {
+        self::assertSame(['baz' => 'foo'], $this->subject->pop());
+        self::assertSame(['foo' => 'baz'], $this->subject->pop());
+
+        $this->subject->reset();
+
+        self::assertSame(['baz' => 'foo'], $this->subject->pop());
+    }
+}

--- a/Tests/Unit/Renderer/Helper/VarDumpHelperTest.php
+++ b/Tests/Unit/Renderer/Helper/VarDumpHelperTest.php
@@ -37,16 +37,33 @@ use TYPO3\TestingFramework;
 #[Framework\Attributes\CoversClass(Src\Renderer\Helper\VarDumpHelper::class)]
 final class VarDumpHelperTest extends TestingFramework\Core\Unit\UnitTestCase
 {
+    private Src\Renderer\Helper\VarDumpHelper $subject;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->subject = new Src\Renderer\Helper\VarDumpHelper();
+    }
+
     #[Framework\Attributes\Test]
     public function evaluateReturnsDumpedContext(): void
     {
         Core\Utility\DebugUtility::useAnsiColor(false);
 
-        $context = [
-            '_this' => [
-                'foo' => 'baz',
-            ],
+        $renderingContext = [
+            'foo' => 'baz',
         ];
+        $data = [];
+        $stack = [];
+
+        $context = new Src\Renderer\Helper\Context\HelperContext(
+            [],
+            [],
+            new Src\Renderer\Helper\Context\RenderingContextStack($stack),
+            $renderingContext,
+            $data,
+        );
 
         $expected = <<<EOF
 Debug
@@ -54,7 +71,7 @@ array(1 item)
    foo => "baz" (3 chars)
 EOF;
 
-        self::assertSame($expected, Src\Renderer\Helper\VarDumpHelper::evaluate($context));
+        self::assertSame($expected, $this->subject->render($context));
 
         Core\Utility\DebugUtility::useAnsiColor(true);
     }


### PR DESCRIPTION
This PR extends the existing `HelperInterface` by a new `render` method. The new method serves as official rendering entrypoint for custom helpers. It receives a `HelperContext` instance which is built around lightncandy's crazy array notation.