### PR TITLE
[!!!][FEATURE] Migrate handlebars layout action mode to enum

### DIFF
--- a/Classes/Renderer/Component/Layout/HandlebarsLayout.php
+++ b/Classes/Renderer/Component/Layout/HandlebarsLayout.php
@@ -51,11 +51,11 @@ class HandlebarsLayout
         ($this->parseFunction)();
     }
 
-    public function addAction(string $name, HandlebarsLayoutAction $action): void
+    public function addAction(HandlebarsLayoutAction $action): void
     {
-        if (!isset($this->actions[$name])) {
-            $this->actions[$name] = [];
-        }
+        $name = $action->getName();
+
+        $this->actions[$name] ??= [];
         $this->actions[$name][] = $action;
     }
 

--- a/Classes/Renderer/Component/Layout/HandlebarsLayoutActionMode.php
+++ b/Classes/Renderer/Component/Layout/HandlebarsLayoutActionMode.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of the TYPO3 CMS extension "handlebars".
  *
- * Copyright (C) 2024 Elias Häußler <e.haeussler@familie-redlich.de>
+ * Copyright (C) 2025 Elias Häußler <e.haeussler@familie-redlich.de>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -23,35 +23,20 @@ declare(strict_types=1);
 
 namespace Fr\Typo3Handlebars\Renderer\Component\Layout;
 
-use Fr\Typo3Handlebars\Renderer;
-
 /**
- * HandlebarsLayoutAction
+ * HandlebarsLayoutActionMode
  *
  * @author Elias Häußler <e.haeussler@familie-redlich.de>
  * @license GPL-2.0-or-later
  */
-final readonly class HandlebarsLayoutAction
+enum HandlebarsLayoutActionMode: string
 {
-    public function __construct(
-        private string $name,
-        private Renderer\Helper\Context\HelperContext $context,
-        private HandlebarsLayoutActionMode $mode = HandlebarsLayoutActionMode::Replace,
-    ) {}
+    case Append = 'append';
+    case Replace = 'replace';
+    case Prepend = 'prepend';
 
-    public function render(string $value): string
+    public static function tryFromCaseInsensitive(string $mode): ?self
     {
-        $renderResult = $this->context->renderChildren($this->context->renderingContext);
-
-        return match ($this->mode) {
-            HandlebarsLayoutActionMode::Append => $value . $renderResult,
-            HandlebarsLayoutActionMode::Prepend => $renderResult . $value,
-            HandlebarsLayoutActionMode::Replace => $renderResult,
-        };
-    }
-
-    public function getName(): string
-    {
-        return $this->name;
+        return self::tryFrom(\strtolower($mode));
     }
 }

--- a/Classes/Renderer/Helper/ContentHelper.php
+++ b/Classes/Renderer/Helper/ContentHelper.php
@@ -44,7 +44,6 @@ final readonly class ContentHelper implements HelperInterface
     public function render(Context\HelperContext $context): ?bool
     {
         $name = $context[0];
-        $mode = $context['mode'] ?? Renderer\Component\Layout\HandlebarsLayoutAction::REPLACE;
         $layoutStack = $this->getLayoutStack($context);
 
         // Early return if "content" helper is requested outside of an "extend" helper block
@@ -55,6 +54,14 @@ final readonly class ContentHelper implements HelperInterface
             );
 
             return $context->isBlockHelper() ? null : false;
+        }
+
+        // Get layout action mode
+        if (isset($context['mode'])) {
+            $mode = Renderer\Component\Layout\HandlebarsLayoutActionMode::tryFromCaseInsensitive($context['mode'])
+                ?? Renderer\Component\Layout\HandlebarsLayoutActionMode::Replace;
+        } else {
+            $mode = Renderer\Component\Layout\HandlebarsLayoutActionMode::Replace;
         }
 
         // Get upper layout from stack
@@ -70,8 +77,8 @@ final readonly class ContentHelper implements HelperInterface
         }
 
         // Add concrete action for the requested block
-        $action = new Renderer\Component\Layout\HandlebarsLayoutAction($context, $mode);
-        $layout->addAction($name, $action);
+        $action = new Renderer\Component\Layout\HandlebarsLayoutAction($name, $context, $mode);
+        $layout->addAction($action);
 
         // This helper does not return any content, it's just here to register layout actions
         return null;

--- a/Tests/Unit/Renderer/Component/Layout/HandlebarsLayoutActionTest.php
+++ b/Tests/Unit/Renderer/Component/Layout/HandlebarsLayoutActionTest.php
@@ -56,25 +56,24 @@ final class HandlebarsLayoutActionTest extends TestingFramework\Core\Unit\UnitTe
         );
     }
 
-    /**
-     * @param Src\Renderer\Component\Layout\HandlebarsLayoutAction::* $mode
-     */
     #[Framework\Attributes\Test]
     #[Framework\Attributes\DataProvider('renderReturnsProcessedValueDataProvider')]
-    public function renderReturnsProcessedValue(string $mode, string $expected): void
-    {
-        $subject = new Src\Renderer\Component\Layout\HandlebarsLayoutAction($this->context, $mode);
+    public function renderReturnsProcessedValue(
+        Src\Renderer\Component\Layout\HandlebarsLayoutActionMode $mode,
+        string $expected,
+    ): void {
+        $subject = new Src\Renderer\Component\Layout\HandlebarsLayoutAction('foo', $this->context, $mode);
 
         self::assertSame($expected, $subject->render('foo'));
     }
 
     /**
-     * @return \Generator<string, array{Src\Renderer\Component\Layout\HandlebarsLayoutAction::*, string}>
+     * @return \Generator<string, array{Src\Renderer\Component\Layout\HandlebarsLayoutActionMode, string}>
      */
     public static function renderReturnsProcessedValueDataProvider(): \Generator
     {
-        yield 'replace' => [Src\Renderer\Component\Layout\HandlebarsLayoutAction::REPLACE, 'baz'];
-        yield 'append' => [Src\Renderer\Component\Layout\HandlebarsLayoutAction::APPEND, 'foobaz'];
-        yield 'prepend' => [Src\Renderer\Component\Layout\HandlebarsLayoutAction::PREPEND, 'bazfoo'];
+        yield 'append' => [Src\Renderer\Component\Layout\HandlebarsLayoutActionMode::Append, 'foobaz'];
+        yield 'prepend' => [Src\Renderer\Component\Layout\HandlebarsLayoutActionMode::Prepend, 'bazfoo'];
+        yield 'replace' => [Src\Renderer\Component\Layout\HandlebarsLayoutActionMode::Replace, 'baz'];
     }
 }


### PR DESCRIPTION
This PR migrates the class constants `APPEND`, `PREPEND` and `REPLACE` in `HandlebarsLayoutAction` to an enum with appropriate cases. In addition, action names are now stored in the actions itself rather than in the consuming layout.