### PR TITLE
[BUGFIX] Respect extension configuration for helper registration

### DIFF
--- a/Classes/DependencyInjection/FeatureRegistrationPass.php
+++ b/Classes/DependencyInjection/FeatureRegistrationPass.php
@@ -65,12 +65,12 @@ final class FeatureRegistrationPass implements DependencyInjection\Compiler\Comp
     /**
      * @param class-string<Renderer\Helper\HelperInterface> $className
      */
-    private function activateHelper(string $name, string $className, string $methodName = 'evaluate'): void
+    private function activateHelper(string $name, string $className): void
     {
         $definition = $this->container->getDefinition($className);
         $definition->addTag('handlebars.helper', [
             'identifier' => $name,
-            'method' => $methodName,
+            'method' => 'render',
         ]);
     }
 

--- a/Classes/Renderer/Helper/BlockHelper.php
+++ b/Classes/Renderer/Helper/BlockHelper.php
@@ -23,7 +23,6 @@ declare(strict_types=1);
 
 namespace Fr\Typo3Handlebars\Renderer\Helper;
 
-use Fr\Typo3Handlebars\Attribute;
 use Fr\Typo3Handlebars\Exception;
 use Fr\Typo3Handlebars\Renderer;
 
@@ -34,7 +33,6 @@ use Fr\Typo3Handlebars\Renderer;
  * @license GPL-2.0-or-later
  * @see https://github.com/shannonmoeller/handlebars-layouts#block-name
  */
-#[Attribute\AsHelper('block')]
 final readonly class BlockHelper implements HelperInterface
 {
     /**

--- a/Classes/Renderer/Helper/ContentHelper.php
+++ b/Classes/Renderer/Helper/ContentHelper.php
@@ -23,7 +23,6 @@ declare(strict_types=1);
 
 namespace Fr\Typo3Handlebars\Renderer\Helper;
 
-use Fr\Typo3Handlebars\Attribute;
 use Fr\Typo3Handlebars\Renderer;
 use Psr\Log;
 
@@ -34,7 +33,6 @@ use Psr\Log;
  * @license GPL-2.0-or-later
  * @see https://github.com/shannonmoeller/handlebars-layouts#content-name-modeappendprependreplace
  */
-#[Attribute\AsHelper('content')]
 final readonly class ContentHelper implements HelperInterface
 {
     private const DEFAULT_MODE = Renderer\Component\Layout\HandlebarsLayoutActionMode::Replace;

--- a/Classes/Renderer/Helper/ExtendHelper.php
+++ b/Classes/Renderer/Helper/ExtendHelper.php
@@ -23,7 +23,6 @@ declare(strict_types=1);
 
 namespace Fr\Typo3Handlebars\Renderer\Helper;
 
-use Fr\Typo3Handlebars\Attribute;
 use Fr\Typo3Handlebars\Renderer;
 
 /**
@@ -33,7 +32,6 @@ use Fr\Typo3Handlebars\Renderer;
  * @license GPL-2.0-or-later
  * @see https://github.com/shannonmoeller/handlebars-layouts#extend-partial-context-keyvalue-
  */
-#[Attribute\AsHelper('extend')]
 final readonly class ExtendHelper implements HelperInterface
 {
     public function __construct(

--- a/Classes/Renderer/Helper/RenderHelper.php
+++ b/Classes/Renderer/Helper/RenderHelper.php
@@ -23,7 +23,6 @@ declare(strict_types=1);
 
 namespace Fr\Typo3Handlebars\Renderer\Helper;
 
-use Fr\Typo3Handlebars\Attribute;
 use Fr\Typo3Handlebars\DataProcessing;
 use Fr\Typo3Handlebars\Exception;
 use Fr\Typo3Handlebars\Renderer;
@@ -38,7 +37,6 @@ use TYPO3\CMS\Frontend;
  * @license GPL-2.0-or-later
  * @see https://github.com/frctl/fractal/blob/main/packages/handlebars/src/helpers/render.js
  */
-#[Attribute\AsHelper('render')]
 final readonly class RenderHelper implements HelperInterface
 {
     public function __construct(

--- a/Tests/Unit/DependencyInjection/FeatureRegistrationPassTest.php
+++ b/Tests/Unit/DependencyInjection/FeatureRegistrationPassTest.php
@@ -117,7 +117,7 @@ final class FeatureRegistrationPassTest extends TestingFramework\Core\Unit\UnitT
         $serviceIds = $container->findTaggedServiceIds('handlebars.helper');
         $expectedConfiguration = [
             'identifier' => $name,
-            'method' => 'evaluate',
+            'method' => 'render',
         ];
 
         self::assertArrayHasKey($className, $serviceIds);

--- a/Tests/Unit/Renderer/Helper/VarDumpHelperTest.php
+++ b/Tests/Unit/Renderer/Helper/VarDumpHelperTest.php
@@ -47,7 +47,7 @@ final class VarDumpHelperTest extends TestingFramework\Core\Unit\UnitTestCase
     }
 
     #[Framework\Attributes\Test]
-    public function evaluateReturnsDumpedContext(): void
+    public function renderReturnsDumpedContext(): void
     {
         Core\Utility\DebugUtility::useAnsiColor(false);
 


### PR DESCRIPTION
Helpers shipped with EXT:handlebars should not be auto-registered, but instead respect extension configuration and use the provided feature registration pass to register each enabled helper.