### PR TITLE
[!!!][TASK] Streamline view configuration across path providers

### DIFF
--- a/Classes/DependencyInjection/Extension/Configuration.php
+++ b/Classes/DependencyInjection/Extension/Configuration.php
@@ -34,7 +34,7 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
  * - defaultData:
  *   - [data]: any default data passed to the renderer
  *
- * - template:
+ * - view:
  *   - [templateRootPaths]: numeric array of template root paths
  *   - [partialRootPaths]: numeric array of partial root paths
  *
@@ -57,7 +57,7 @@ final class Configuration implements ConfigurationInterface
                     ->performNoDeepMerging()
                     ->variablePrototype()->end()
                 ->end()
-                ->arrayNode('template')
+                ->arrayNode('view')
                     ->children()
                         ->arrayNode('templateRootPaths')
                             ->beforeNormalization()

--- a/Classes/DependencyInjection/Extension/HandlebarsExtension.php
+++ b/Classes/DependencyInjection/Extension/HandlebarsExtension.php
@@ -75,8 +75,8 @@ final class HandlebarsExtension extends Extension
      */
     private function parseConfiguration(array $configs): void
     {
-        $templateConfig = $this->mergeConfigs($configs, 'template');
         $this->defaultData = $this->mergeConfigs($configs, 'default_data');
+        $templateConfig = $this->mergeConfigs($configs, 'view');
         $this->templateRootPaths = $templateConfig['templateRootPaths'] ?? [];
         $this->partialRootPaths = $templateConfig['partialRootPaths'] ?? [];
     }

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -28,6 +28,6 @@ services:
 
 handlebars:
   default_data: []
-  template:
+  view:
     templateRootPaths: []
     partialRootPaths: []

--- a/Documentation/Configuration/TemplatePaths/Index.rst
+++ b/Documentation/Configuration/TemplatePaths/Index.rst
@@ -27,7 +27,7 @@ is by using the :file:`Services.yaml` file:
     # Configuration/Services.yaml
 
     handlebars:
-      template:
+      view:
         templateRootPaths:
           10: EXT:my_extension/Resources/Private/Templates
         partialRootPaths:

--- a/Tests/Unit/DependencyInjection/Extension/HandlebarsExtensionTest.php
+++ b/Tests/Unit/DependencyInjection/Extension/HandlebarsExtensionTest.php
@@ -117,12 +117,12 @@ final class HandlebarsExtensionTest extends TestingFramework\Core\Unit\UnitTestC
         yield 'template root paths' => [
             [
                 [
-                    'template' => [
+                    'view' => [
                         'templateRootPaths' => $firstRootPaths,
                     ],
                 ],
                 [
-                    'template' => [
+                    'view' => [
                         'templateRootPaths' => $secondRootPaths,
                     ],
                 ],
@@ -136,12 +136,12 @@ final class HandlebarsExtensionTest extends TestingFramework\Core\Unit\UnitTestC
         yield 'partial root paths' => [
             [
                 [
-                    'template' => [
+                    'view' => [
                         'partialRootPaths' => $firstRootPaths,
                     ],
                 ],
                 [
-                    'template' => [
+                    'view' => [
                         'partialRootPaths' => $secondRootPaths,
                     ],
                 ],


### PR DESCRIPTION
This PR streamlines the view configuration of all template path providers by renaming the global root path configuration in service container from `template` to `view`:

```diff
 # Configuration/Services.yaml

 handlebars:
   default_data: []
-  template:
+  view:
     templateRootPaths: []
     partialRootPaths: []
```