### PR TITLE
[!!!][TASK] Streamline root context with TYPO3 default naming

### DIFF
--- a/Classes/DependencyInjection/Extension/Configuration.php
+++ b/Classes/DependencyInjection/Extension/Configuration.php
@@ -31,8 +31,8 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
  *
  * Defines the following configuration structure for the {@see HandlebarsExtension}:
  *
- * - defaultData:
- *   - [data]: any default data passed to the renderer
+ * - variables:
+ *   - [data]: any default variable passed to the renderer
  *
  * - view:
  *   - [templateRootPaths]: numeric array of template root paths
@@ -48,12 +48,12 @@ final class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('handlebars');
-        $rootNode = $treeBuilder->getRootNode();
 
-        /** @phpstan-ignore-next-line */
-        $rootNode
+        /* @phpstan-ignore method.notFound */
+        $treeBuilder
+            ->getRootNode()
             ->children()
-                ->arrayNode('default_data')
+                ->arrayNode('variables')
                     ->performNoDeepMerging()
                     ->variablePrototype()->end()
                 ->end()

--- a/Classes/DependencyInjection/Extension/HandlebarsExtension.php
+++ b/Classes/DependencyInjection/Extension/HandlebarsExtension.php
@@ -36,9 +36,9 @@ use TYPO3\CMS\Core\Utility\ArrayUtility;
  */
 final class HandlebarsExtension extends Extension
 {
-    public const PARAMETER_DEFAULT_DATA = 'handlebars.default_data';
     public const PARAMETER_TEMPLATE_ROOT_PATHS = 'handlebars.templateRootPaths';
     public const PARAMETER_PARTIAL_ROOT_PATHS = 'handlebars.partialRootPaths';
+    public const PARAMETER_ROOT_CONTEXT = 'handlebars.rootContext';
 
     /**
      * @var string[]
@@ -53,7 +53,7 @@ final class HandlebarsExtension extends Extension
     /**
      * @var array<string|int, mixed>
      */
-    private array $defaultData = [];
+    private array $rootContext = [];
 
     /**
      * @param array<string|int, mixed>[] $configs
@@ -64,9 +64,9 @@ final class HandlebarsExtension extends Extension
         $this->parseConfiguration($configs);
 
         $container->getParameterBag()->add([
-            self::PARAMETER_DEFAULT_DATA => $this->defaultData,
             self::PARAMETER_TEMPLATE_ROOT_PATHS => $this->templateRootPaths,
             self::PARAMETER_PARTIAL_ROOT_PATHS => $this->partialRootPaths,
+            self::PARAMETER_ROOT_CONTEXT => $this->rootContext,
         ]);
     }
 
@@ -75,10 +75,11 @@ final class HandlebarsExtension extends Extension
      */
     private function parseConfiguration(array $configs): void
     {
-        $this->defaultData = $this->mergeConfigs($configs, 'default_data');
         $templateConfig = $this->mergeConfigs($configs, 'view');
+
         $this->templateRootPaths = $templateConfig['templateRootPaths'] ?? [];
         $this->partialRootPaths = $templateConfig['partialRootPaths'] ?? [];
+        $this->rootContext = $this->mergeConfigs($configs, 'variables');
     }
 
     /**
@@ -88,16 +89,18 @@ final class HandlebarsExtension extends Extension
     private function mergeConfigs(array $configs, string $configKey): array
     {
         $mergedConfig = [];
+
         foreach (array_column($configs, $configKey) as $concreteConfig) {
             ArrayUtility::mergeRecursiveWithOverrule($mergedConfig, $concreteConfig);
         }
+
         return $mergedConfig;
     }
 
     private function reset(): void
     {
-        $this->defaultData = [];
         $this->templateRootPaths = [];
         $this->partialRootPaths = [];
+        $this->rootContext = [];
     }
 }

--- a/Classes/Event/BeforeRenderingEvent.php
+++ b/Classes/Event/BeforeRenderingEvent.php
@@ -34,11 +34,11 @@ use Fr\Typo3Handlebars\Renderer\HandlebarsRenderer;
 class BeforeRenderingEvent
 {
     /**
-     * @param array<string|int, mixed> $data
+     * @param array<string|int, mixed> $variables
      */
     public function __construct(
         private readonly string $templatePath,
-        private array $data,
+        private array $variables,
         private readonly HandlebarsRenderer $renderer,
     ) {}
 
@@ -50,17 +50,17 @@ class BeforeRenderingEvent
     /**
      * @return array<string|int, mixed>
      */
-    public function getData(): array
+    public function getVariables(): array
     {
-        return $this->data;
+        return $this->variables;
     }
 
     /**
-     * @param array<string|int, mixed> $data
+     * @param array<string|int, mixed> $variables
      */
-    public function setData(array $data): self
+    public function setVariables(array $variables): self
     {
-        $this->data = $data;
+        $this->variables = $variables;
         return $this;
     }
 

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -27,7 +27,7 @@ services:
     arguments: ['handlebars']
 
 handlebars:
-  default_data: []
+  variables: []
   view:
     templateRootPaths: []
     partialRootPaths: []

--- a/Documentation/Configuration/Index.rst
+++ b/Documentation/Configuration/Index.rst
@@ -21,5 +21,5 @@ how to use the extension:
 
     Cache/Index
     TemplatePaths/Index
-    DefaultData/Index
+    Variables/Index
     Debugging/Index

--- a/Documentation/Configuration/Variables/Index.rst
+++ b/Documentation/Configuration/Variables/Index.rst
@@ -11,7 +11,7 @@ data. This can be, for example, paths to assets or other firmly defined
 content such as e-mail addresses or names/labels/etc.
 
 The standard `HandlebarsRenderer` provides the possibility to specify an
-array :php:`$defaultData` for this purpose. This data is merged with the
+array :php:`$rootContext` for this purpose. This data is merged with the
 concrete render data during each rendering and passed on to the `Renderer`.
 
 ..  _configure-default-data:
@@ -26,11 +26,11 @@ In your :file:`Services.yaml` file, add the following lines:
     # Configuration/Services.yaml
 
     handlebars:
-      default_data:
+      variables:
         publicPath: /assets
         # ...
 
-All data will then be available as service parameter `%handlebars.default_data%`
+All data will then be available as service parameter `%handlebars.variables%`
 within the service container. So you can use it everywhere you need it in
 your :file:`Services.yaml` file.
 

--- a/Tests/Unit/DependencyInjection/Extension/HandlebarsExtensionTest.php
+++ b/Tests/Unit/DependencyInjection/Extension/HandlebarsExtensionTest.php
@@ -86,32 +86,32 @@ final class HandlebarsExtensionTest extends TestingFramework\Core\Unit\UnitTestC
         yield 'no configs' => [
             [],
             [
-                Src\DependencyInjection\Extension\HandlebarsExtension::PARAMETER_DEFAULT_DATA => [],
                 Src\DependencyInjection\Extension\HandlebarsExtension::PARAMETER_TEMPLATE_ROOT_PATHS => [],
                 Src\DependencyInjection\Extension\HandlebarsExtension::PARAMETER_PARTIAL_ROOT_PATHS => [],
+                Src\DependencyInjection\Extension\HandlebarsExtension::PARAMETER_ROOT_CONTEXT => [],
             ],
         ];
         yield 'default data' => [
             [
                 [
-                    'default_data' => [
+                    'variables' => [
                         'foo' => 'baz',
                     ],
                 ],
                 [
-                    'default_data' => [
+                    'variables' => [
                         'foo' => 'yay',
                         'baz' => 'foo',
                     ],
                 ],
             ],
             [
-                Src\DependencyInjection\Extension\HandlebarsExtension::PARAMETER_DEFAULT_DATA => [
+                Src\DependencyInjection\Extension\HandlebarsExtension::PARAMETER_TEMPLATE_ROOT_PATHS => [],
+                Src\DependencyInjection\Extension\HandlebarsExtension::PARAMETER_PARTIAL_ROOT_PATHS => [],
+                Src\DependencyInjection\Extension\HandlebarsExtension::PARAMETER_ROOT_CONTEXT => [
                     'foo' => 'yay',
                     'baz' => 'foo',
                 ],
-                Src\DependencyInjection\Extension\HandlebarsExtension::PARAMETER_TEMPLATE_ROOT_PATHS => [],
-                Src\DependencyInjection\Extension\HandlebarsExtension::PARAMETER_PARTIAL_ROOT_PATHS => [],
             ],
         ];
         yield 'template root paths' => [
@@ -128,9 +128,9 @@ final class HandlebarsExtensionTest extends TestingFramework\Core\Unit\UnitTestC
                 ],
             ],
             [
-                Src\DependencyInjection\Extension\HandlebarsExtension::PARAMETER_DEFAULT_DATA => [],
                 Src\DependencyInjection\Extension\HandlebarsExtension::PARAMETER_TEMPLATE_ROOT_PATHS => $expectedRootPaths,
                 Src\DependencyInjection\Extension\HandlebarsExtension::PARAMETER_PARTIAL_ROOT_PATHS => [],
+                Src\DependencyInjection\Extension\HandlebarsExtension::PARAMETER_ROOT_CONTEXT => [],
             ],
         ];
         yield 'partial root paths' => [
@@ -147,9 +147,9 @@ final class HandlebarsExtensionTest extends TestingFramework\Core\Unit\UnitTestC
                 ],
             ],
             [
-                Src\DependencyInjection\Extension\HandlebarsExtension::PARAMETER_DEFAULT_DATA => [],
                 Src\DependencyInjection\Extension\HandlebarsExtension::PARAMETER_TEMPLATE_ROOT_PATHS => [],
                 Src\DependencyInjection\Extension\HandlebarsExtension::PARAMETER_PARTIAL_ROOT_PATHS => $expectedRootPaths,
+                Src\DependencyInjection\Extension\HandlebarsExtension::PARAMETER_ROOT_CONTEXT => [],
             ],
         ];
     }

--- a/Tests/Unit/Event/BeforeRenderingEventTest.php
+++ b/Tests/Unit/Event/BeforeRenderingEventTest.php
@@ -56,17 +56,17 @@ final class BeforeRenderingEventTest extends TestingFramework\Core\Unit\UnitTest
     }
 
     #[Framework\Attributes\Test]
-    public function getDataReturnsData(): void
+    public function getVariablesReturnsVariables(): void
     {
-        self::assertSame(['foo' => 'baz'], $this->subject->getData());
+        self::assertSame(['foo' => 'baz'], $this->subject->getVariables());
     }
 
     #[Framework\Attributes\Test]
-    public function setDataModifiesData(): void
+    public function setVariablesModifiesVariables(): void
     {
-        $this->subject->setData(['modified' => 'data']);
+        $this->subject->setVariables(['modified' => 'variables']);
 
-        self::assertSame(['modified' => 'data'], $this->subject->getData());
+        self::assertSame(['modified' => 'variables'], $this->subject->getVariables());
     }
 
     #[Framework\Attributes\Test]

--- a/Tests/Unit/Renderer/HandlebarsRendererTest.php
+++ b/Tests/Unit/Renderer/HandlebarsRendererTest.php
@@ -102,10 +102,10 @@ final class HandlebarsRendererTest extends TestingFramework\Core\Unit\UnitTestCa
     }
 
     #[Framework\Attributes\Test]
-    public function renderMergesDefaultDataWithGivenData(): void
+    public function renderMergesVariablesWithGivenVariables(): void
     {
         $this->helperRegistry->add('varDump', Src\Renderer\Helper\VarDumpHelper::class);
-        $this->subject->setDefaultData([
+        $this->subject->setRootContext([
             'foo' => 'baz',
         ]);
 
@@ -241,10 +241,11 @@ EOF;
     }
 
     #[Framework\Attributes\Test]
-    public function getDefaultDataReturnsDefaultRenderData(): void
+    public function getRootContextReturnsDefaultVariables(): void
     {
-        $this->subject->setDefaultData(['foo' => 'baz']);
-        self::assertSame(['foo' => 'baz'], $this->subject->getDefaultData());
+        $this->subject->setRootContext(['foo' => 'baz']);
+
+        self::assertSame(['foo' => 'baz'], $this->subject->getRootContext());
     }
 
     private function assertCacheIsEmptyForTemplate(string $template): void
@@ -264,6 +265,7 @@ EOF;
     protected function tearDown(): void
     {
         self::assertTrue($this->clearCache(), 'Unable to clear Handlebars cache.');
+
         parent::tearDown();
     }
 


### PR DESCRIPTION
This PR streamlines the naming of default data (also referenced as "root context") from `default_data` to `variables`, according to the naming used in Fluid context:

```diff
 # Configuration/Services.yaml

 handlebars:
-  default_data:
+  variables:
     foo: baz
   view:
     templateRootPaths: []
     partialRootPaths: []
```