### PR TITLE
[!!!][FEATURE] Introduce `VariableProvider` for default variables

### DIFF
--- a/Classes/DependencyInjection/Extension/HandlebarsExtension.php
+++ b/Classes/DependencyInjection/Extension/HandlebarsExtension.php
@@ -38,7 +38,7 @@ final class HandlebarsExtension extends Extension
 {
     public const PARAMETER_TEMPLATE_ROOT_PATHS = 'handlebars.templateRootPaths';
     public const PARAMETER_PARTIAL_ROOT_PATHS = 'handlebars.partialRootPaths';
-    public const PARAMETER_ROOT_CONTEXT = 'handlebars.rootContext';
+    public const PARAMETER_ROOT_CONTEXT = 'handlebars.variables';
 
     /**
      * @var string[]

--- a/Classes/Renderer/HandlebarsRenderer.php
+++ b/Classes/Renderer/HandlebarsRenderer.php
@@ -57,9 +57,6 @@ class HandlebarsRenderer implements RendererInterface
 {
     protected readonly bool $debugMode;
 
-    /**
-     * @param array<string|int, mixed> $rootContext
-     */
     public function __construct(
         #[Autowire('@handlebars.cache')]
         protected readonly CacheInterface $cache,
@@ -68,8 +65,7 @@ class HandlebarsRenderer implements RendererInterface
         protected readonly LoggerInterface $logger,
         #[Autowire('@handlebars.template_resolver')]
         protected readonly TemplateResolverInterface $templateResolver,
-        #[Autowire('%handlebars.variables%')]
-        protected array $rootContext = [],
+        protected readonly Variables\VariableBag $variableBag,
     ) {
         $this->debugMode = $this->isDebugModeEnabled();
     }
@@ -106,8 +102,8 @@ class HandlebarsRenderer implements RendererInterface
             return '';
         }
 
-        // Merge render data with root context
-        $mergedVariables = array_merge($this->rootContext, $variables);
+        // Merge variables with default variables
+        $mergedVariables = array_merge($this->variableBag->get(), $variables);
 
         // Compile template
         $compileResult = $this->compile($template);
@@ -254,23 +250,6 @@ class HandlebarsRenderer implements RendererInterface
     public function resolvePartial(array $context, string $name): ?string
     {
         return file_get_contents($this->templateResolver->resolvePartialPath($name)) ?: null;
-    }
-
-    /**
-     * @return array<string|int, mixed>
-     */
-    public function getRootContext(): array
-    {
-        return $this->rootContext;
-    }
-
-    /**
-     * @param array<string|int, mixed> $rootContext
-     */
-    public function setRootContext(array $rootContext): self
-    {
-        $this->rootContext = $rootContext;
-        return $this;
     }
 
     protected function isCachingDisabled(): bool

--- a/Classes/Renderer/Variables/GlobalVariableProvider.php
+++ b/Classes/Renderer/Variables/GlobalVariableProvider.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "handlebars".
+ *
+ * Copyright (C) 2025 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace Fr\Typo3Handlebars\Renderer\Variables;
+
+use Symfony\Component\DependencyInjection;
+
+/**
+ * GlobalVariableProvider
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-2.0-or-later
+ */
+final readonly class GlobalVariableProvider implements VariableProvider
+{
+    /**
+     * @param array<string, mixed> $variables
+     */
+    public function __construct(
+        #[DependencyInjection\Attribute\Autowire('%handlebars.variables%')]
+        private array $variables,
+    ) {}
+
+    public function get(): array
+    {
+        return $this->variables;
+    }
+
+    public function offsetExists(mixed $offset): bool
+    {
+        return isset($this->variables[$offset]);
+    }
+
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->variables[$offset] ?? null;
+    }
+
+    public function offsetSet(mixed $offset, mixed $value): never
+    {
+        throw new \LogicException('Variables cannot be modified.', 1736274549);
+    }
+
+    public function offsetUnset(mixed $offset): never
+    {
+        throw new \LogicException('Variables cannot be modified.', 1736274551);
+    }
+
+    public static function getPriority(): int
+    {
+        return 0;
+    }
+}

--- a/Classes/Renderer/Variables/TypoScriptVariableProvider.php
+++ b/Classes/Renderer/Variables/TypoScriptVariableProvider.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "handlebars".
+ *
+ * Copyright (C) 2025 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace Fr\Typo3Handlebars\Renderer\Variables;
+
+use Fr\Typo3Handlebars\Configuration;
+use TYPO3\CMS\Extbase;
+
+/**
+ * TypoScriptVariableProvider
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-2.0-or-later
+ */
+final class TypoScriptVariableProvider implements VariableProvider
+{
+    /**
+     * @var array<string, mixed>|null
+     */
+    private ?array $variables = null;
+
+    public function __construct(
+        private readonly Extbase\Configuration\ConfigurationManagerInterface $configurationManager,
+    ) {}
+
+    public function get(): array
+    {
+        if ($this->variables === null) {
+            $this->variables = $this->fetchVariables();
+        }
+
+        return $this->variables;
+    }
+
+    public function offsetExists(mixed $offset): bool
+    {
+        return isset($this->get()[$offset]);
+    }
+
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->get()[$offset] ?? null;
+    }
+
+    public function offsetSet(mixed $offset, mixed $value): never
+    {
+        throw new \LogicException('Variables cannot be modified.', 1736274326);
+    }
+
+    public function offsetUnset(mixed $offset): never
+    {
+        throw new \LogicException('Variables cannot be modified.', 1736274336);
+    }
+
+    public static function getPriority(): int
+    {
+        return 50;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function fetchVariables(): array
+    {
+        $typoScriptConfiguration = $this->configurationManager->getConfiguration(
+            Extbase\Configuration\ConfigurationManagerInterface::CONFIGURATION_TYPE_FRAMEWORK,
+            Configuration\Extension::NAME,
+        );
+
+        return $typoScriptConfiguration['variables'] ?? [];
+    }
+}

--- a/Classes/Renderer/Variables/VariableBag.php
+++ b/Classes/Renderer/Variables/VariableBag.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "handlebars".
+ *
+ * Copyright (C) 2025 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace Fr\Typo3Handlebars\Renderer\Variables;
+
+use Symfony\Component\DependencyInjection;
+use TYPO3\CMS\Core\Utility\ArrayUtility;
+
+/**
+ * VariableBag
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-2.0-or-later
+ * @implements \ArrayAccess<string, mixed>
+ */
+final class VariableBag implements \ArrayAccess
+{
+    /**
+     * @var array<string, mixed>|null
+     */
+    private ?array $variables = null;
+
+    /**
+     * @param iterable<VariableProvider> $providers
+     */
+    public function __construct(
+        #[DependencyInjection\Attribute\AutowireIterator('handlebars.variable_provider', defaultPriorityMethod: 'getPriority')]
+        private readonly iterable $providers,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function get(): array
+    {
+        if ($this->variables === null) {
+            $this->variables = $this->fetchVariablesFromProviders();
+        }
+
+        return $this->variables;
+    }
+
+    public function offsetExists(mixed $offset): bool
+    {
+        return isset($this->get()[$offset]);
+    }
+
+    public function offsetGet(mixed $offset): mixed
+    {
+        return $this->get()[$offset] ?? null;
+    }
+
+    public function offsetSet(mixed $offset, mixed $value): never
+    {
+        throw new \LogicException('Variables cannot be modified.', 1736274871);
+    }
+
+    public function offsetUnset(mixed $offset): never
+    {
+        throw new \LogicException('Variables cannot be modified.', 1736274873);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function fetchVariablesFromProviders(): array
+    {
+        $providerVariables = [];
+        $mergedVariables = [];
+
+        foreach ($this->providers as $provider) {
+            \array_unshift($providerVariables, $provider->get());
+        }
+
+        foreach ($providerVariables as $variables) {
+            ArrayUtility::mergeRecursiveWithOverrule($mergedVariables, $variables);
+        }
+
+        return $mergedVariables;
+    }
+}

--- a/Classes/Renderer/Variables/VariableProvider.php
+++ b/Classes/Renderer/Variables/VariableProvider.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "handlebars".
+ *
+ * Copyright (C) 2025 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace Fr\Typo3Handlebars\Renderer\Variables;
+
+use Symfony\Component\DependencyInjection;
+
+/**
+ * VariableProvider
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-2.0-or-later
+ * @extends \ArrayAccess<string, mixed>
+ */
+#[DependencyInjection\Attribute\AutoconfigureTag('handlebars.variable_provider')]
+interface VariableProvider extends \ArrayAccess
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function get(): array;
+
+    public static function getPriority(): int;
+}

--- a/Tests/Functional/Renderer/Helper/BlockHelperTest.php
+++ b/Tests/Functional/Renderer/Helper/BlockHelperTest.php
@@ -65,6 +65,7 @@ final class BlockHelperTest extends TestingFramework\Core\Functional\FunctionalT
             $helperRegistry,
             new Log\NullLogger(),
             $this->templateResolver,
+            new Src\Renderer\Variables\VariableBag([]),
         );
 
         $helperRegistry->add('extend', new Src\Renderer\Helper\ExtendHelper($this->renderer));

--- a/Tests/Functional/Renderer/Helper/ContentHelperTest.php
+++ b/Tests/Functional/Renderer/Helper/ContentHelperTest.php
@@ -67,6 +67,7 @@ final class ContentHelperTest extends TestingFramework\Core\Functional\Functiona
             $helperRegistry,
             $this->logger,
             $this->templateResolver,
+            new Src\Renderer\Variables\VariableBag([]),
         );
 
         $helperRegistry->add('extend', new Src\Renderer\Helper\ExtendHelper($this->renderer));

--- a/Tests/Functional/Renderer/Helper/ExtendHelperTest.php
+++ b/Tests/Functional/Renderer/Helper/ExtendHelperTest.php
@@ -66,6 +66,7 @@ final class ExtendHelperTest extends TestingFramework\Core\Functional\Functional
             $helperRegistry,
             new Log\NullLogger(),
             $this->templateResolver,
+            new Src\Renderer\Variables\VariableBag([]),
         );
 
         $helperRegistry->add('extend', new Src\Renderer\Helper\ExtendHelper($this->renderer));

--- a/Tests/Functional/Renderer/Helper/RenderHelperTest.php
+++ b/Tests/Functional/Renderer/Helper/RenderHelperTest.php
@@ -69,6 +69,7 @@ final class RenderHelperTest extends TestingFramework\Core\Functional\Functional
             $helperRegistry,
             new Log\NullLogger(),
             $this->templateResolver,
+            new Src\Renderer\Variables\VariableBag([]),
         );
         $this->contentObjectRenderer = new Frontend\ContentObject\ContentObjectRenderer();
         $this->contentObjectRenderer->start([]);

--- a/Tests/Unit/DataProcessing/AbstractDataProcessorTest.php
+++ b/Tests/Unit/DataProcessing/AbstractDataProcessorTest.php
@@ -63,6 +63,7 @@ final class AbstractDataProcessorTest extends TestingFramework\Core\Unit\UnitTes
                 new Src\Renderer\Helper\HelperRegistry($this->logger),
                 $this->logger,
                 $this->getTemplateResolver(),
+                new Src\Renderer\Variables\VariableBag([]),
             ),
         );
         $this->provider = new Tests\Unit\Fixtures\Classes\Data\DummyProvider();

--- a/Tests/Unit/DataProcessing/SimpleProcessorTest.php
+++ b/Tests/Unit/DataProcessing/SimpleProcessorTest.php
@@ -63,6 +63,7 @@ final class SimpleProcessorTest extends TestingFramework\Core\Unit\UnitTestCase
             $this->helperRegistry,
             $this->logger,
             $this->getTemplateResolver(),
+            new Src\Renderer\Variables\VariableBag([]),
         );
         $this->subject = new Src\DataProcessing\SimpleProcessor($this->logger, $this->renderer);
         $this->subject->setContentObjectRenderer($this->contentObjectRendererMock);

--- a/Tests/Unit/Renderer/HandlebarsRendererTest.php
+++ b/Tests/Unit/Renderer/HandlebarsRendererTest.php
@@ -105,9 +105,6 @@ final class HandlebarsRendererTest extends TestingFramework\Core\Unit\UnitTestCa
     public function renderMergesVariablesWithGivenVariables(): void
     {
         $this->helperRegistry->add('varDump', Src\Renderer\Helper\VarDumpHelper::class);
-        $this->subject->setRootContext([
-            'foo' => 'baz',
-        ]);
 
         Core\Utility\DebugUtility::useAnsiColor(false);
 
@@ -240,14 +237,6 @@ EOF;
         );
     }
 
-    #[Framework\Attributes\Test]
-    public function getRootContextReturnsDefaultVariables(): void
-    {
-        $this->subject->setRootContext(['foo' => 'baz']);
-
-        self::assertSame(['foo' => 'baz'], $this->subject->getRootContext());
-    }
-
     private function assertCacheIsEmptyForTemplate(string $template): void
     {
         self::assertNull(
@@ -283,6 +272,11 @@ EOF;
             $this->helperRegistry,
             $this->logger,
             $this->getTemplateResolver(),
+            new Src\Renderer\Variables\VariableBag([
+                new Src\Renderer\Variables\GlobalVariableProvider([
+                    'foo' => 'baz',
+                ]),
+            ]),
         );
     }
 

--- a/Tests/Unit/Renderer/Template/Path/TypoScriptPathProviderTest.php
+++ b/Tests/Unit/Renderer/Template/Path/TypoScriptPathProviderTest.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace Fr\Typo3Handlebars\Tests\Unit\Renderer\Template\Path;
 
 use Fr\Typo3Handlebars as Src;
+use Fr\Typo3Handlebars\Tests;
 use PHPUnit\Framework;
 use TYPO3\TestingFramework;
 
@@ -36,14 +37,14 @@ use TYPO3\TestingFramework;
 #[Framework\Attributes\CoversClass(Src\Renderer\Template\Path\TypoScriptPathProvider::class)]
 final class TypoScriptPathProviderTest extends TestingFramework\Core\Unit\UnitTestCase
 {
-    private Src\Tests\Unit\Fixtures\Classes\DummyConfigurationManager $configurationManager;
+    private Tests\Unit\Fixtures\Classes\DummyConfigurationManager $configurationManager;
     private Src\Renderer\Template\Path\TypoScriptPathProvider $subject;
 
     public function setUp(): void
     {
         parent::setUp();
 
-        $this->configurationManager = new Src\Tests\Unit\Fixtures\Classes\DummyConfigurationManager();
+        $this->configurationManager = new Tests\Unit\Fixtures\Classes\DummyConfigurationManager();
         $this->subject = new Src\Renderer\Template\Path\TypoScriptPathProvider($this->configurationManager);
     }
 

--- a/Tests/Unit/Renderer/Variables/GlobalVariableProviderTest.php
+++ b/Tests/Unit/Renderer/Variables/GlobalVariableProviderTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "handlebars".
+ *
+ * Copyright (C) 2025 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace Fr\Typo3Handlebars\Tests\Unit\Renderer\Variables;
+
+use Fr\Typo3Handlebars as Src;
+use PHPUnit\Framework;
+use TYPO3\TestingFramework;
+
+/**
+ * GlobalVariableProviderTest
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-2.0-or-later
+ */
+#[Framework\Attributes\CoversClass(Src\Renderer\Variables\GlobalVariableProvider::class)]
+final class GlobalVariableProviderTest extends TestingFramework\Core\Unit\UnitTestCase
+{
+    private Src\Renderer\Variables\GlobalVariableProvider $subject;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->subject = new Src\Renderer\Variables\GlobalVariableProvider([
+            'foo' => 'baz',
+        ]);
+    }
+
+    #[Framework\Attributes\Test]
+    public function getReturnsVariables(): void
+    {
+        self::assertSame(['foo' => 'baz'], $this->subject->get());
+    }
+
+    #[Framework\Attributes\Test]
+    public function objectCanBeAccessedAsReadOnlyArray(): void
+    {
+        // offsetExists
+        self::assertTrue(isset($this->subject['foo']));
+        self::assertFalse(isset($this->subject['baz']));
+
+        // offsetGet
+        self::assertSame('baz', $this->subject['foo']);
+        self::assertNull($this->subject['baz']);
+    }
+
+    #[Framework\Attributes\Test]
+    public function offsetSetThrowsLogicException(): void
+    {
+        $this->expectExceptionObject(
+            new \LogicException('Variables cannot be modified.', 1736274549),
+        );
+
+        $this->subject['baz'] = 'foo';
+    }
+
+    #[Framework\Attributes\Test]
+    public function offsetUnsetThrowsLogicException(): void
+    {
+        $this->expectExceptionObject(
+            new \LogicException('Variables cannot be modified.', 1736274551),
+        );
+
+        unset($this->subject['foo']);
+    }
+}

--- a/Tests/Unit/Renderer/Variables/TypoScriptVariableProviderTest.php
+++ b/Tests/Unit/Renderer/Variables/TypoScriptVariableProviderTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "handlebars".
+ *
+ * Copyright (C) 2025 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace Fr\Typo3Handlebars\Tests\Unit\Renderer\Variables;
+
+use Fr\Typo3Handlebars as Src;
+use Fr\Typo3Handlebars\Tests;
+use PHPUnit\Framework;
+use TYPO3\TestingFramework;
+
+/**
+ * TypoScriptVariableProviderTest
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-2.0-or-later
+ */
+#[Framework\Attributes\CoversClass(Src\Renderer\Variables\TypoScriptVariableProvider::class)]
+final class TypoScriptVariableProviderTest extends TestingFramework\Core\Unit\UnitTestCase
+{
+    private Tests\Unit\Fixtures\Classes\DummyConfigurationManager $configurationManager;
+    private Src\Renderer\Variables\TypoScriptVariableProvider $subject;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->configurationManager = new Tests\Unit\Fixtures\Classes\DummyConfigurationManager();
+        $this->configurationManager->configuration = [
+            'variables' => [
+                'foo' => 'baz',
+            ],
+        ];
+
+        $this->subject = new Src\Renderer\Variables\TypoScriptVariableProvider($this->configurationManager);
+    }
+
+    #[Framework\Attributes\Test]
+    public function getReturnsVariablesFetchedViaConfigurationManager(): void
+    {
+        self::assertSame(['foo' => 'baz'], $this->subject->get());
+    }
+
+    #[Framework\Attributes\Test]
+    public function getCachesFetchedVariables(): void
+    {
+        self::assertSame(['foo' => 'baz'], $this->subject->get());
+
+        $this->configurationManager->configuration = [];
+
+        self::assertSame(['foo' => 'baz'], $this->subject->get());
+    }
+
+    #[Framework\Attributes\Test]
+    public function objectCanBeAccessedAsReadOnlyArray(): void
+    {
+        // offsetExists
+        self::assertTrue(isset($this->subject['foo']));
+        self::assertFalse(isset($this->subject['baz']));
+
+        // offsetGet
+        self::assertSame('baz', $this->subject['foo']);
+        self::assertNull($this->subject['baz']);
+    }
+
+    #[Framework\Attributes\Test]
+    public function offsetSetThrowsLogicException(): void
+    {
+        $this->expectExceptionObject(
+            new \LogicException('Variables cannot be modified.', 1736274326),
+        );
+
+        $this->subject['baz'] = 'foo';
+    }
+
+    #[Framework\Attributes\Test]
+    public function offsetUnsetThrowsLogicException(): void
+    {
+        $this->expectExceptionObject(
+            new \LogicException('Variables cannot be modified.', 1736274336),
+        );
+
+        unset($this->subject['foo']);
+    }
+}

--- a/Tests/Unit/Renderer/Variables/VariableBagTest.php
+++ b/Tests/Unit/Renderer/Variables/VariableBagTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "handlebars".
+ *
+ * Copyright (C) 2025 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace Fr\Typo3Handlebars\Tests\Unit\Renderer\Variables;
+
+use Fr\Typo3Handlebars as Src;
+use PHPUnit\Framework;
+use TYPO3\TestingFramework;
+
+/**
+ * VariableBagTest
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-2.0-or-later
+ */
+#[Framework\Attributes\CoversClass(Src\Renderer\Variables\VariableBag::class)]
+final class VariableBagTest extends TestingFramework\Core\Unit\UnitTestCase
+{
+    private Src\Renderer\Variables\VariableBag $subject;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->subject = new Src\Renderer\Variables\VariableBag([
+            new Src\Renderer\Variables\GlobalVariableProvider([
+                'foo' => 'boo',
+                'baz' => 'foo',
+            ]),
+            new Src\Renderer\Variables\GlobalVariableProvider([
+                'foo' => 'baz',
+            ]),
+        ]);
+    }
+
+    #[Framework\Attributes\Test]
+    public function getReturnsMergedVariablesFromProviders(): void
+    {
+        $expected = [
+            'foo' => 'boo',
+            'baz' => 'foo',
+        ];
+
+        self::assertSame($expected, $this->subject->get());
+    }
+
+    #[Framework\Attributes\Test]
+    public function objectCanBeAccessedAsReadOnlyArray(): void
+    {
+        // offsetExists
+        self::assertTrue(isset($this->subject['foo']));
+        self::assertTrue(isset($this->subject['baz']));
+        self::assertFalse(isset($this->subject['boo']));
+
+        // offsetGet
+        self::assertSame('boo', $this->subject['foo']);
+        self::assertSame('foo', $this->subject['baz']);
+        self::assertNull($this->subject['boo']);
+    }
+
+    #[Framework\Attributes\Test]
+    public function offsetSetThrowsLogicException(): void
+    {
+        $this->expectExceptionObject(
+            new \LogicException('Variables cannot be modified.', 1736274871),
+        );
+
+        $this->subject['boo'] = 'baz';
+    }
+
+    #[Framework\Attributes\Test]
+    public function offsetUnsetThrowsLogicException(): void
+    {
+        $this->expectExceptionObject(
+            new \LogicException('Variables cannot be modified.', 1736274873),
+        );
+
+        unset($this->subject['foo']);
+    }
+}


### PR DESCRIPTION
This PR introduces a new `VariableProvider` component. It wraps the `variables` (previously `default_data`) section from service container which allows to provide default variables for use in each rendering. The new component is open for custom implementations. In addition, this PR adds support for definition of default variables using TypoScript (see `TypoScriptVariableProvider`). All variables from variables providers are merged together in the new `VariableBag` component which serves as entrypoint to fetch final default variables.