### PR TITLE
[BUGFIX] Respect handling of path provider priority in `TemplatePaths`

### DIFF
--- a/Classes/Renderer/Template/TemplatePaths.php
+++ b/Classes/Renderer/Template/TemplatePaths.php
@@ -88,7 +88,7 @@ final class TemplatePaths
         $paths = [];
 
         foreach ($this->pathProviders as $pathProvider) {
-            $paths[] = $mapFunction($pathProvider);
+            \array_unshift($paths, $mapFunction($pathProvider));
         }
 
         $mergedPaths = array_replace(...$paths);

--- a/Tests/Unit/Renderer/Template/TemplatePathsTest.php
+++ b/Tests/Unit/Renderer/Template/TemplatePathsTest.php
@@ -48,8 +48,8 @@ final class TemplatePathsTest extends TestingFramework\Core\Unit\UnitTestCase
 
         $this->pathProvider = new Tests\Unit\Fixtures\Classes\Renderer\Template\Path\DummyPathProvider();
         $this->subject = new Src\Renderer\Template\TemplatePaths([
-            new Src\Renderer\Template\Path\GlobalPathProvider($this->getViewConfiguration()),
             $this->pathProvider,
+            new Src\Renderer\Template\Path\GlobalPathProvider($this->getViewConfiguration()),
         ]);
     }
 


### PR DESCRIPTION
`PathProvider` instances are sorted by priority when passed as tagged iterator to `TemplatePaths`. Providers with higher priority are higher located than providers with lower priority. This was not properly reflected when iterating through providers, which is corrected by this PR.