### PR TITLE
[FEATURE] Allow modifying a single variable in `BeforeRenderingEvent`

### DIFF
--- a/Classes/Event/BeforeRenderingEvent.php
+++ b/Classes/Event/BeforeRenderingEvent.php
@@ -64,6 +64,18 @@ class BeforeRenderingEvent
         return $this;
     }
 
+    public function addVariable(string $name, mixed $value): self
+    {
+        $this->variables[$name] = $value;
+        return $this;
+    }
+
+    public function removeVariable(string $name): self
+    {
+        unset($this->variables[$name]);
+        return $this;
+    }
+
     public function getRenderer(): HandlebarsRenderer
     {
         return $this->renderer;

--- a/Tests/Unit/Event/BeforeRenderingEventTest.php
+++ b/Tests/Unit/Event/BeforeRenderingEventTest.php
@@ -70,6 +70,29 @@ final class BeforeRenderingEventTest extends TestingFramework\Core\Unit\UnitTest
     }
 
     #[Framework\Attributes\Test]
+    public function addVariableAddsSingleVariable(): void
+    {
+        $this->subject->addVariable('foo', 'boo');
+        $this->subject->addVariable('baz', 'foo');
+
+        self::assertSame(
+            [
+                'foo' => 'boo',
+                'baz' => 'foo',
+            ],
+            $this->subject->getVariables(),
+        );
+    }
+
+    #[Framework\Attributes\Test]
+    public function removeVariableRemoveSingleVariable(): void
+    {
+        $this->subject->removeVariable('foo');
+
+        self::assertSame([], $this->subject->getVariables());
+    }
+
+    #[Framework\Attributes\Test]
     public function getRendererReturnsRenderer(): void
     {
         self::assertInstanceOf(Src\Renderer\HandlebarsRenderer::class, $this->subject->getRenderer());


### PR DESCRIPTION
This PR extends the `BeforeRenderingEvent` to allow adding and removing a single variable using the `addVariable` and `removeVariable` methods.