### PR TITLE
[FEATURE] Populate and read cacheable state of template path providers

### DIFF
--- a/Classes/Renderer/Template/Path/GlobalPathProvider.php
+++ b/Classes/Renderer/Template/Path/GlobalPathProvider.php
@@ -70,6 +70,11 @@ final readonly class GlobalPathProvider implements PathProvider
         return $this->templateRootPaths;
     }
 
+    public function isCacheable(): bool
+    {
+        return true;
+    }
+
     public static function getPriority(): int
     {
         return 0;

--- a/Classes/Renderer/Template/Path/PathProvider.php
+++ b/Classes/Renderer/Template/Path/PathProvider.php
@@ -47,5 +47,7 @@ interface PathProvider
      */
     public function getTemplateRootPaths(): array;
 
+    public function isCacheable(): bool;
+
     public static function getPriority(): int;
 }

--- a/Classes/Renderer/Template/Path/TypoScriptPathProvider.php
+++ b/Classes/Renderer/Template/Path/TypoScriptPathProvider.php
@@ -53,6 +53,11 @@ final class TypoScriptPathProvider implements PathProvider
         return $this->getViewConfiguration()[self::TEMPLATES] ?? [];
     }
 
+    public function isCacheable(): bool
+    {
+        return true;
+    }
+
     /**
      * @return array{partialRootPaths?: array<int, string>, templateRootPaths?: array<int, string>}
      */

--- a/Tests/Unit/Fixtures/Classes/Renderer/Template/Path/DummyPathProvider.php
+++ b/Tests/Unit/Fixtures/Classes/Renderer/Template/Path/DummyPathProvider.php
@@ -41,6 +41,7 @@ final class DummyPathProvider implements Renderer\Template\Path\PathProvider
     public function __construct(
         public array $templateRootPaths = [],
         public array $partialRootPaths = [],
+        public bool $cacheable = true,
     ) {}
 
     public function getPartialRootPaths(): array
@@ -51,6 +52,11 @@ final class DummyPathProvider implements Renderer\Template\Path\PathProvider
     public function getTemplateRootPaths(): array
     {
         return $this->templateRootPaths;
+    }
+
+    public function isCacheable(): bool
+    {
+        return $this->cacheable;
     }
 
     public static function getPriority(): int

--- a/Tests/Unit/Renderer/Template/TemplatePathsTest.php
+++ b/Tests/Unit/Renderer/Template/TemplatePathsTest.php
@@ -54,21 +54,6 @@ final class TemplatePathsTest extends TestingFramework\Core\Unit\UnitTestCase
     }
 
     /**
-     * @param array<int, string> $templateRootPaths
-     * @param array<int, string> $expected
-     */
-    #[Framework\Attributes\Test]
-    #[Framework\Attributes\DataProvider('getTemplateRootPathsMergesConfigurationFromPathProvidersDataProvider')]
-    public function getTemplateRootPathsMergesConfigurationFromPathProviders(
-        array $templateRootPaths,
-        array $expected,
-    ): void {
-        $this->pathProvider->templateRootPaths = $templateRootPaths;
-
-        self::assertSame($expected, $this->subject->getTemplateRootPaths());
-    }
-
-    /**
      * @param array<int, string> $partialRootPaths
      * @param array<int, string> $expected
      */
@@ -83,15 +68,118 @@ final class TemplatePathsTest extends TestingFramework\Core\Unit\UnitTestCase
         self::assertSame($expected, $this->subject->getPartialRootPaths());
     }
 
+    #[Framework\Attributes\Test]
+    public function getPartialRootPathsCachesRootPathsIfAllPathProvidersAreCacheable(): void
+    {
+        $this->pathProvider->partialRootPaths = [
+            20 => 'foo',
+        ];
+
+        $expected = [
+            10 => dirname(__DIR__, 2) . '/Fixtures/Partials',
+            20 => 'foo',
+        ];
+
+        self::assertSame($expected, $this->subject->getPartialRootPaths());
+
+        $this->pathProvider->partialRootPaths = [
+            20 => 'baz',
+        ];
+
+        self::assertSame($expected, $this->subject->getPartialRootPaths());
+    }
+
+    #[Framework\Attributes\Test]
+    public function getPartialRootPathsDoesNotCacheRootPathsIfAnyPathProviderIsNonCacheable(): void
+    {
+        $this->pathProvider->cacheable = false;
+
+        $expected = [
+            10 => dirname(__DIR__, 2) . '/Fixtures/Partials',
+        ];
+
+        self::assertSame($expected, $this->subject->getPartialRootPaths());
+
+        $this->pathProvider->partialRootPaths = [
+            20 => 'foo',
+        ];
+
+        $expected = [
+            10 => dirname(__DIR__, 2) . '/Fixtures/Partials',
+            20 => 'foo',
+        ];
+
+        self::assertSame($expected, $this->subject->getPartialRootPaths());
+    }
+
+    /**
+     * @param array<int, string> $templateRootPaths
+     * @param array<int, string> $expected
+     */
+    #[Framework\Attributes\Test]
+    #[Framework\Attributes\DataProvider('getTemplateRootPathsMergesConfigurationFromPathProvidersDataProvider')]
+    public function getTemplateRootPathsMergesConfigurationFromPathProviders(
+        array $templateRootPaths,
+        array $expected,
+    ): void {
+        $this->pathProvider->templateRootPaths = $templateRootPaths;
+
+        self::assertSame($expected, $this->subject->getTemplateRootPaths());
+    }
+
+    #[Framework\Attributes\Test]
+    public function getTemplateRootPathsCachesRootPathsIfAllPathProvidersAreCacheable(): void
+    {
+        $this->pathProvider->templateRootPaths = [
+            20 => 'foo',
+        ];
+
+        $expected = [
+            10 => dirname(__DIR__, 2) . '/Fixtures/Templates',
+            20 => 'foo',
+        ];
+
+        self::assertSame($expected, $this->subject->getTemplateRootPaths());
+
+        $this->pathProvider->templateRootPaths = [
+            20 => 'baz',
+        ];
+
+        self::assertSame($expected, $this->subject->getTemplateRootPaths());
+    }
+
+    #[Framework\Attributes\Test]
+    public function getTemplateRootPathsDoesNotCacheRootPathsIfAnyPathProviderIsNonCacheable(): void
+    {
+        $this->pathProvider->cacheable = false;
+
+        $expected = [
+            10 => dirname(__DIR__, 2) . '/Fixtures/Templates',
+        ];
+
+        self::assertSame($expected, $this->subject->getTemplateRootPaths());
+
+        $this->pathProvider->templateRootPaths = [
+            20 => 'foo',
+        ];
+
+        $expected = [
+            10 => dirname(__DIR__, 2) . '/Fixtures/Templates',
+            20 => 'foo',
+        ];
+
+        self::assertSame($expected, $this->subject->getTemplateRootPaths());
+    }
+
     /**
      * @return \Generator<string, array{array<int, string>, array<int, string>}>
      */
-    public static function getTemplateRootPathsMergesConfigurationFromPathProvidersDataProvider(): \Generator
+    public static function getPartialRootPathsMergesConfigurationFromPathProvidersDataProvider(): \Generator
     {
         yield 'no view configuration' => [
             [],
             [
-                10 => dirname(__DIR__, 2) . '/Fixtures/Templates',
+                10 => dirname(__DIR__, 2) . '/Fixtures/Partials',
             ],
         ];
         yield 'view configuration with identical keys' => [
@@ -117,12 +205,12 @@ final class TemplatePathsTest extends TestingFramework\Core\Unit\UnitTestCase
     /**
      * @return \Generator<string, array{array<int, string>, array<int, string>}>
      */
-    public static function getPartialRootPathsMergesConfigurationFromPathProvidersDataProvider(): \Generator
+    public static function getTemplateRootPathsMergesConfigurationFromPathProvidersDataProvider(): \Generator
     {
         yield 'no view configuration' => [
             [],
             [
-                10 => dirname(__DIR__, 2) . '/Fixtures/Partials',
+                10 => dirname(__DIR__, 2) . '/Fixtures/Templates',
             ],
         ];
         yield 'view configuration with identical keys' => [


### PR DESCRIPTION
This PR extends the `PathProvider` interface by an `isCacheable` method. It describes the possibility of path providers to provide cached root paths. This information is used in `TemplatePaths` when building final root paths.