### PR TITLE
[FEATURE] Introduce `HANDLEBARSTEMPLATE` content object

### DIFF
--- a/Classes/Frontend/ContentObject/HandlebarsTemplateContentObject.php
+++ b/Classes/Frontend/ContentObject/HandlebarsTemplateContentObject.php
@@ -1,0 +1,185 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "handlebars".
+ *
+ * Copyright (C) 2025 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace Fr\Typo3Handlebars\Frontend\ContentObject;
+
+use Fr\Typo3Handlebars\Renderer;
+use TYPO3\CMS\Core;
+use TYPO3\CMS\Frontend;
+
+/**
+ * HandlebarsTemplateContentObject
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-2.0-or-later
+ */
+final class HandlebarsTemplateContentObject extends Frontend\ContentObject\FluidTemplateContentObject
+{
+    public function __construct(
+        Frontend\ContentObject\ContentDataProcessor $contentDataProcessor,
+        private readonly Renderer\Renderer $renderer,
+        private readonly Renderer\Template\Path\ContentObjectPathProvider $pathProvider,
+        private readonly Core\TypoScript\TypoScriptService $typoScriptService,
+    ) {
+        parent::__construct($contentDataProcessor);
+    }
+
+    /**
+     * @param array<string, mixed> $conf
+     */
+    public function render($conf = []): string
+    {
+        if (!is_array($conf)) {
+            $conf = [];
+        }
+
+        // Create handlebars view
+        $view = $this->createView($conf);
+
+        // Resolve template paths
+        /** @var array<string, mixed> $templatePaths */
+        $templatePaths = $this->typoScriptService->convertTypoScriptArrayToPlainArray(
+            array_intersect_key(
+                $conf,
+                [
+                    'partialRootPath' => true,
+                    'partialRootPaths.' => true,
+                    'templateRootPath' => true,
+                    'templateRootPaths.' => true,
+                ],
+            ),
+        );
+
+        // Populate template paths for availability in subsequent renderings
+        $this->pathProvider->push($templatePaths);
+
+        $view->assignMultiple($this->resolveVariables($conf));
+
+        $this->renderPageAssetsIntoPageRenderer($conf, $view);
+
+        try {
+            $content = $this->renderer->render($view);
+        } finally {
+            // Remove current content object rendering from path provider stack
+            $this->pathProvider->pop();
+        }
+
+        return $this->applyStandardWrapToRenderedContent($content, $conf);
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     */
+    private function createView(array $config): Renderer\Template\View\HandlebarsView
+    {
+        $format = $this->cObj?->stdWrapValue('format', $config, null);
+        $view = new Renderer\Template\View\HandlebarsView();
+
+        if (is_string($format)) {
+            $view->setFormat($format);
+        }
+
+        if (isset($config['templateName']) || isset($config['templateName.'])) {
+            return $view->setTemplatePath(
+                (string)$this->cObj?->stdWrapValue('templateName', $config),
+            );
+        }
+
+        if (isset($config['template']) || isset($config['template.'])) {
+            return $view->setTemplateSource(
+                (string)$this->cObj?->stdWrapValue('template', $config),
+            );
+        }
+
+        if (isset($config['file']) || isset($config['file.'])) {
+            return $view->setTemplatePath(
+                (string)$this->cObj?->stdWrapValue('file', $config),
+            );
+        }
+
+        return $view;
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     * @return array<string, mixed>
+     */
+    private function resolveVariables(array $config): array
+    {
+        $variables = $this->getContentObjectVariables($config);
+
+        // Resolve variables from simple hierarchy (without content objects)
+        $simpleVariables = \array_diff_key(
+            $this->typoScriptService->convertTypoScriptArrayToPlainArray($config['variables.'] ?? []),
+            $variables,
+        );
+
+        // Merge variables
+        if ($simpleVariables !== []) {
+            Core\Utility\ArrayUtility::mergeRecursiveWithOverrule($variables, $simpleVariables);
+        }
+
+        // Process variables with configured data processors
+        if ($this->cObj !== null) {
+            $variables = $this->contentDataProcessor->process($this->cObj, $config, $variables);
+        }
+
+        if (isset($config['settings.'])) {
+            $variables['settings'] = $this->typoScriptService->convertTypoScriptArrayToPlainArray($config['settings.']);
+        }
+
+        return $variables;
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     */
+    private function renderPageAssetsIntoPageRenderer(array $config, Renderer\Template\View\HandlebarsView $baseView): void
+    {
+        $headerAssets = $this->renderAssets($config['headerAssets.'] ?? [], $baseView);
+        $footerAssets = $this->renderAssets($config['footerAssets.'] ?? [], $baseView);
+
+        if (\trim($headerAssets) !== '') {
+            $this->getPageRenderer()->addHeaderData($headerAssets);
+        }
+
+        if (\trim($footerAssets) !== '') {
+            $this->getPageRenderer()->addFooterData($footerAssets);
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     */
+    private function renderAssets(array $config, Renderer\Template\View\HandlebarsView $baseView): string
+    {
+        if ($config === []) {
+            return '';
+        }
+
+        $view = $this->createView($config);
+        $view->assignMultiple($baseView->getVariables());
+
+        return $this->renderer->render($view);
+    }
+}

--- a/Classes/Renderer/Template/BaseTemplateResolver.php
+++ b/Classes/Renderer/Template/BaseTemplateResolver.php
@@ -39,16 +39,6 @@ abstract class BaseTemplateResolver implements TemplateResolver
     /**
      * @var list<string>
      */
-    protected array $partialRootPaths = [];
-
-    /**
-     * @var list<string>
-     */
-    protected array $templateRootPaths = [];
-
-    /**
-     * @var list<string>
-     */
     protected array $supportedFileExtensions = self::DEFAULT_FILE_EXTENSIONS;
 
     public function supports(string $fileExtension): bool

--- a/Classes/Renderer/Template/HandlebarsTemplateResolver.php
+++ b/Classes/Renderer/Template/HandlebarsTemplateResolver.php
@@ -34,6 +34,16 @@ use Fr\Typo3Handlebars\Exception;
 final class HandlebarsTemplateResolver extends BaseTemplateResolver
 {
     /**
+     * @var list<string>
+     */
+    protected array $partialRootPaths = [];
+
+    /**
+     * @var list<string>
+     */
+    protected array $templateRootPaths = [];
+
+    /**
      * @param string[] $supportedFileExtensions
      * @throws Exception\RootPathIsMalicious
      * @throws Exception\RootPathIsNotResolvable

--- a/Classes/Renderer/Template/Path/ContentObjectPathProvider.php
+++ b/Classes/Renderer/Template/Path/ContentObjectPathProvider.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "handlebars".
+ *
+ * Copyright (C) 2025 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace Fr\Typo3Handlebars\Renderer\Template\Path;
+
+use TYPO3\CMS\Core;
+
+/**
+ * ContentObjectPathProvider
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-2.0-or-later
+ *
+ * @phpstan-type RootPathStackItem array{
+ *     current: array<int, string>,
+ *     merged: array<int, string>|null,
+ * }
+ */
+final class ContentObjectPathProvider implements PathProvider, Core\SingletonInterface
+{
+    /**
+     * @var list<array{
+     *     partialRootPaths: RootPathStackItem,
+     *     templateRootPaths: RootPathStackItem,
+     * }>
+     */
+    private array $stack = [];
+
+    private ?int $currentItem = null;
+
+    /**
+     * @param array<string, mixed> $configuration
+     */
+    public function push(array $configuration): void
+    {
+        $partialRootPaths = [];
+        $templateRootPaths = [];
+
+        if (is_array($configuration['templateRootPaths'] ?? null)) {
+            $templateRootPaths = $configuration['templateRootPaths'];
+        }
+        if (is_array($configuration['partialRootPaths'] ?? null)) {
+            $partialRootPaths = $configuration['partialRootPaths'];
+        }
+
+        // A single root path receives highest priority
+        if (is_string($configuration['templateRootPath'] ?? null)) {
+            $templateRootPaths[PHP_INT_MAX] = $configuration['templateRootPath'];
+        }
+        if (is_string($configuration['partialRootPath'] ?? null)) {
+            $partialRootPaths[PHP_INT_MAX] = $configuration['partialRootPath'];
+        }
+
+        \ksort($templateRootPaths);
+        \ksort($partialRootPaths);
+
+        $this->stack[] = [
+            'partialRootPaths' => [
+                'current' => $partialRootPaths,
+                'merged' => null,
+            ],
+            'templateRootPaths' => [
+                'current' => $templateRootPaths,
+                'merged' => null,
+            ],
+        ];
+
+        if ($this->currentItem === null) {
+            $this->currentItem = 0;
+        } else {
+            $this->currentItem++;
+        }
+    }
+
+    public function pop(): void
+    {
+        if ($this->stack === []) {
+            return;
+        }
+
+        array_pop($this->stack);
+
+        if ($this->stack === []) {
+            $this->currentItem = null;
+        } else {
+            $this->currentItem--;
+        }
+    }
+
+    public function isEmpty(): bool
+    {
+        return $this->currentItem === null;
+    }
+
+    public function getPartialRootPaths(): array
+    {
+        return $this->getMergedRootPathsFromStack('partialRootPaths');
+    }
+
+    public function getTemplateRootPaths(): array
+    {
+        return $this->getMergedRootPathsFromStack('templateRootPaths');
+    }
+
+    public function isCacheable(): bool
+    {
+        // Caching is done internally, based on the current stack
+        return false;
+    }
+
+    /**
+     * @param 'partialRootPaths'|'templateRootPaths' $type
+     * @return array<int, string>
+     */
+    private function getMergedRootPathsFromStack(string $type): array
+    {
+        if ($this->currentItem === null) {
+            return [];
+        }
+
+        // Merge and cache root paths
+        if ($this->stack[$this->currentItem][$type]['merged'] === null) {
+            $this->stack[$this->currentItem][$type]['merged'] = $this->stack[0][$type]['current'];
+
+            for ($i = 1; $i <= $this->currentItem; $i++) {
+                Core\Utility\ArrayUtility::mergeRecursiveWithOverrule(
+                    $this->stack[$this->currentItem][$type]['merged'],
+                    $this->stack[$i][$type]['current'],
+                );
+            }
+
+            \ksort($this->stack[$this->currentItem][$type]['merged']);
+        }
+
+        return $this->stack[$this->currentItem][$type]['merged'];
+    }
+
+    public static function getPriority(): int
+    {
+        return 100;
+    }
+}

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -16,6 +16,12 @@ services:
   Fr\Typo3Handlebars\Renderer\Template\TemplateResolver:
     alias: 'handlebars.template_resolver'
 
+  # Content object
+  Fr\Typo3Handlebars\Frontend\ContentObject\HandlebarsTemplateContentObject:
+    tags:
+      - name: frontend.contentobject
+        identifier: 'HANDLEBARSTEMPLATE'
+
   # Template
   handlebars.template_resolver:
     class: 'Fr\Typo3Handlebars\Renderer\Template\HandlebarsTemplateResolver'

--- a/Tests/Functional/Fixtures/DummyRenderer.php
+++ b/Tests/Functional/Fixtures/DummyRenderer.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "handlebars".
+ *
+ * Copyright (C) 2025 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace Fr\Typo3Handlebars\Tests\Functional\Fixtures;
+
+use Fr\Typo3Handlebars\Renderer;
+
+/**
+ * DummyRenderer
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-2.0-or-later
+ * @internal
+ */
+final class DummyRenderer implements Renderer\Renderer
+{
+    /**
+     * @var (\Closure(Renderer\Template\View\HandlebarsView): string|null)|null
+     */
+    public ?\Closure $testClosure = null;
+    public ?Renderer\Template\View\HandlebarsView $lastView = null;
+
+    public function render(Renderer\Template\View\HandlebarsView $view): string
+    {
+        $result = null;
+
+        $this->lastView = $view;
+
+        if ($this->testClosure !== null) {
+            $result = ($this->testClosure)($view);
+        }
+
+        return $result ?? $view->getTemplate();
+    }
+}

--- a/Tests/Functional/Frontend/ContentObject/HandlebarsTemplateContentObjectTest.php
+++ b/Tests/Functional/Frontend/ContentObject/HandlebarsTemplateContentObjectTest.php
@@ -1,0 +1,354 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "handlebars".
+ *
+ * Copyright (C) 2025 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace Fr\Typo3Handlebars\Tests\Functional\Frontend\ContentObject;
+
+use Fr\Typo3Handlebars as Src;
+use Fr\Typo3Handlebars\Tests;
+use PHPUnit\Framework;
+use TYPO3\CMS\Core;
+use TYPO3\CMS\Frontend;
+use TYPO3\TestingFramework;
+
+/**
+ * HandlebarsTemplateContentObjectTest
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-2.0-or-later
+ */
+#[Framework\Attributes\CoversClass(Src\Frontend\ContentObject\HandlebarsTemplateContentObject::class)]
+final class HandlebarsTemplateContentObjectTest extends TestingFramework\Core\Functional\FunctionalTestCase
+{
+    protected array $testExtensionsToLoad = [
+        'handlebars',
+    ];
+
+    private Tests\Functional\Fixtures\DummyRenderer $renderer;
+    private Src\Renderer\Template\Path\ContentObjectPathProvider $pathProvider;
+    private Src\Frontend\ContentObject\HandlebarsTemplateContentObject $subject;
+    private Frontend\ContentObject\ContentObjectRenderer $contentObjectRenderer;
+    private Core\Page\PageRenderer $pageRenderer;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $request = new Core\Http\ServerRequest('https://typo3-testing.local/');
+
+        $this->renderer = new Tests\Functional\Fixtures\DummyRenderer();
+        $this->pathProvider = $this->get(Src\Renderer\Template\Path\ContentObjectPathProvider::class);
+        $this->subject = new Src\Frontend\ContentObject\HandlebarsTemplateContentObject(
+            $this->get(Frontend\ContentObject\ContentDataProcessor::class),
+            $this->renderer,
+            $this->pathProvider,
+            $this->get(Core\TypoScript\TypoScriptService::class),
+        );
+        $this->contentObjectRenderer = new Frontend\ContentObject\ContentObjectRenderer();
+        $this->pageRenderer = $this->get(Core\Page\PageRenderer::class);
+
+        $this->subject->setRequest($request);
+        $this->subject->setContentObjectRenderer($this->contentObjectRenderer);
+        $this->contentObjectRenderer->setRequest($request);
+    }
+
+    #[Framework\Attributes\Test]
+    public function renderThrowsExceptionIfTemplateIsNotConfigured(): void
+    {
+        $this->expectExceptionObject(
+            new Src\Exception\ViewIsNotProperlyInitialized(),
+        );
+
+        $this->subject->render();
+    }
+
+    #[Framework\Attributes\Test]
+    public function renderAppliesGivenFormatToView(): void
+    {
+        $this->subject->render([
+            'template' => 'foo',
+            'format' => 'hbs',
+        ]);
+
+        self::assertSame('hbs', $this->renderer->lastView?->getFormat());
+    }
+
+    #[Framework\Attributes\Test]
+    public function renderAppliesStdWrapOnFormatConfig(): void
+    {
+        $this->subject->render([
+            'template' => 'foo',
+            'format' => 'hbs',
+            'format.' => [
+                'wrap' => 'html.|',
+            ],
+        ]);
+
+        self::assertSame('html.hbs', $this->renderer->lastView?->getFormat());
+    }
+
+    #[Framework\Attributes\Test]
+    public function renderAppliesGivenTemplateNameToView(): void
+    {
+        $this->expectExceptionObject(
+            new Src\Exception\TemplateFileIsInvalid('foo'),
+        );
+
+        $this->subject->render([
+            'templateName' => 'foo',
+        ]);
+    }
+
+    #[Framework\Attributes\Test]
+    public function renderAppliesStdWrapOnTemplateNameConfig(): void
+    {
+        $this->expectExceptionObject(
+            new Src\Exception\TemplateFileIsInvalid('foo/baz'),
+        );
+
+        $this->subject->render([
+            'templateName' => 'foo',
+            'templateName.' => [
+                'wrap' => '|/baz',
+            ],
+        ]);
+    }
+
+    #[Framework\Attributes\Test]
+    public function renderAppliesGivenTemplateToView(): void
+    {
+        self::assertSame(
+            'foo',
+            $this->subject->render([
+                'template' => 'foo',
+            ]),
+        );
+    }
+
+    #[Framework\Attributes\Test]
+    public function renderAppliesStdWrapOnTemplateConfig(): void
+    {
+        self::assertSame(
+            'foo baz',
+            $this->subject->render([
+                'template' => 'foo',
+                'template.' => [
+                    'noTrimWrap' => '|| baz|',
+                ],
+            ]),
+        );
+    }
+
+    #[Framework\Attributes\Test]
+    public function renderAppliesGivenFileToView(): void
+    {
+        $this->expectExceptionObject(
+            new Src\Exception\TemplateFileIsInvalid('foo'),
+        );
+
+        $this->subject->render([
+            'file' => 'foo',
+        ]);
+    }
+
+    #[Framework\Attributes\Test]
+    public function renderAppliesStdWrapOnFileConfig(): void
+    {
+        $this->expectExceptionObject(
+            new Src\Exception\TemplateFileIsInvalid('foo/baz'),
+        );
+
+        $this->subject->render([
+            'file' => 'foo',
+            'file.' => [
+                'wrap' => '|/baz',
+            ],
+        ]);
+    }
+
+    #[Framework\Attributes\Test]
+    public function renderPushesResolvedTemplatePathsToContentObjectPathProvider(): void
+    {
+        $this->renderer->testClosure = function () {
+            self::assertSame([10 => 'foo'], $this->pathProvider->getTemplateRootPaths());
+            self::assertSame([10 => 'baz'], $this->pathProvider->getPartialRootPaths());
+
+            return 'foo';
+        };
+
+        $this->subject->render([
+            'templateRootPaths.' => [
+                '10' => 'foo',
+            ],
+            'partialRootPaths.' => [
+                '10' => 'baz',
+            ],
+        ]);
+
+        self::assertSame([], $this->pathProvider->getTemplateRootPaths());
+        self::assertSame([], $this->pathProvider->getPartialRootPaths());
+    }
+
+    #[Framework\Attributes\Test]
+    public function renderResolvesAndAppliesVariablesFromConfig(): void
+    {
+        $expected = [
+            'data' => [],
+            'current' => null,
+            'foo' => 'baz',
+        ];
+
+        $this->subject->render([
+            'template' => 'foo',
+            'variables.' => [
+                'foo' => 'TEXT',
+                'foo.' => [
+                    'value' => 'baz',
+                ],
+            ],
+        ]);
+
+        self::assertEquals($expected, $this->renderer->lastView?->getVariables());
+    }
+
+    #[Framework\Attributes\Test]
+    public function renderResolvesAndAppliesSimpleVariablesFromConfig(): void
+    {
+        $expected = [
+            'data' => [],
+            'current' => null,
+            'foo' => [
+                'baz' => 'boo',
+            ],
+        ];
+
+        $this->subject->render([
+            'template' => 'foo',
+            'variables.' => [
+                'foo.' => [
+                    'baz' => 'boo',
+                ],
+            ],
+        ]);
+
+        self::assertEquals($expected, $this->renderer->lastView?->getVariables());
+    }
+
+    #[Framework\Attributes\Test]
+    public function renderCallsDataProcessorsAndAppliesVariables(): void
+    {
+        $this->contentObjectRenderer->data = [
+            'foo' => 'baz,boo',
+        ];
+
+        $expected = [
+            'data' => [
+                'foo' => 'baz,boo',
+            ],
+            'current' => null,
+            'foo' => [
+                [
+                    'baz',
+                    'boo',
+                ],
+            ],
+        ];
+
+        $this->subject->render([
+            'template' => 'foo',
+            'dataProcessing.' => [
+                '10' => 'comma-separated-value',
+                '10.' => [
+                    'fieldName' => 'foo',
+                    'as' => 'foo',
+                ],
+            ],
+        ]);
+
+        self::assertEquals($expected, $this->renderer->lastView?->getVariables());
+    }
+
+    #[Framework\Attributes\Test]
+    public function renderResolvesAndAppliesSettingsFromConfig(): void
+    {
+        $expected = [
+            'data' => [],
+            'current' => null,
+            'settings' => [
+                'foo' => [
+                    'baz' => 'boo',
+                ],
+            ],
+        ];
+
+        $this->subject->render([
+            'template' => 'foo',
+            'settings.' => [
+                'foo.' => [
+                    'baz' => 'boo',
+                ],
+            ],
+        ]);
+
+        self::assertEquals($expected, $this->renderer->lastView?->getVariables());
+    }
+
+    #[Framework\Attributes\Test]
+    public function renderRendersAndAppliesHeaderAssets(): void
+    {
+        $this->subject->render([
+            'template' => 'foo',
+            'headerAssets.' => [
+                'template' => 'foo header assets',
+            ],
+        ]);
+
+        self::assertStringContainsString('foo header assets', $this->pageRenderer->render());
+    }
+
+    #[Framework\Attributes\Test]
+    public function renderRendersAndAppliesFooterAssets(): void
+    {
+        $this->subject->render([
+            'template' => 'foo',
+            'footerAssets.' => [
+                'template' => 'foo footer assets',
+            ],
+        ]);
+
+        self::assertStringContainsString('foo footer assets', $this->pageRenderer->render());
+    }
+
+    #[Framework\Attributes\Test]
+    public function renderAppliesStdWrapToRenderedContent(): void
+    {
+        self::assertSame(
+            'foo baz',
+            $this->subject->render([
+                'template' => 'foo',
+                'stdWrap.' => [
+                    'noTrimWrap' => '|| baz|',
+                ],
+            ]),
+        );
+    }
+}

--- a/Tests/Unit/Renderer/Template/Path/ContentObjectPathProviderTest.php
+++ b/Tests/Unit/Renderer/Template/Path/ContentObjectPathProviderTest.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "handlebars".
+ *
+ * Copyright (C) 2025 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace Fr\Typo3Handlebars\Tests\Unit\Renderer\Template\Path;
+
+use Fr\Typo3Handlebars as Src;
+use PHPUnit\Framework;
+use TYPO3\TestingFramework;
+
+/**
+ * ContentObjectPathProviderTest
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-2.0-or-later
+ */
+#[Framework\Attributes\CoversClass(Src\Renderer\Template\Path\ContentObjectPathProvider::class)]
+final class ContentObjectPathProviderTest extends TestingFramework\Core\Unit\UnitTestCase
+{
+    private const CONFIGURATION_1 = [
+        'templateRootPaths' => [
+            10 => 'foo',
+        ],
+        'partialRootPaths' => [
+            10 => 'baz',
+        ],
+        'templateRootPath' => 'foo with higher priority',
+        'partialRootPath' => 'baz with higher priority',
+    ];
+    private const CONFIGURATION_2 = [
+        'templateRootPaths' => [
+            20 => 'another foo',
+        ],
+        'partialRootPaths' => [
+            20 => 'another baz',
+        ],
+        'templateRootPath' => 'another foo with higher priority',
+        'partialRootPath' => 'another baz with higher priority',
+    ];
+
+    private Src\Renderer\Template\Path\ContentObjectPathProvider $subject;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->subject = new Src\Renderer\Template\Path\ContentObjectPathProvider();
+    }
+
+    #[Framework\Attributes\Test]
+    public function pushAddsConfigurationToStack(): void
+    {
+        $this->subject->push(self::CONFIGURATION_1);
+
+        self::assertFalse($this->subject->isEmpty());
+        self::assertSame(
+            [
+                10 => 'foo',
+                PHP_INT_MAX => 'foo with higher priority',
+            ],
+            $this->subject->getTemplateRootPaths(),
+        );
+        self::assertSame(
+            [
+                10 => 'baz',
+                PHP_INT_MAX => 'baz with higher priority',
+            ],
+            $this->subject->getPartialRootPaths(),
+        );
+    }
+
+    #[Framework\Attributes\Test]
+    public function popRemovesCurrentConfigurationFromStack(): void
+    {
+        $this->subject->push(self::CONFIGURATION_1);
+        $this->subject->push(self::CONFIGURATION_2);
+        $this->subject->pop();
+
+        self::assertFalse($this->subject->isEmpty());
+
+        $this->subject->pop();
+
+        self::assertTrue($this->subject->isEmpty());
+    }
+
+    #[Framework\Attributes\Test]
+    public function popDoesNothingIfStackIsAlreadyEmpty(): void
+    {
+        $this->subject->pop();
+
+        self::assertTrue($this->subject->isEmpty());
+    }
+
+    #[Framework\Attributes\Test]
+    public function getPartialRootPathsReturnsEmptyArrayIfStackIsEmpty(): void
+    {
+        self::assertSame([], $this->subject->getPartialRootPaths());
+    }
+
+    #[Framework\Attributes\Test]
+    public function getPartialRootPathsReturnsMergedRootPathsFromStack(): void
+    {
+        $this->subject->push(self::CONFIGURATION_1);
+        $this->subject->push(self::CONFIGURATION_2);
+
+        self::assertSame(
+            [
+                10 => 'baz',
+                20 => 'another baz',
+                PHP_INT_MAX => 'another baz with higher priority',
+            ],
+            $this->subject->getPartialRootPaths(),
+        );
+    }
+
+    #[Framework\Attributes\Test]
+    public function getTemplateRootPathsReturnsEmptyArrayIfStackIsEmpty(): void
+    {
+        self::assertSame([], $this->subject->getTemplateRootPaths());
+    }
+
+    #[Framework\Attributes\Test]
+    public function getTemplateRootPathsReturnsMergedRootPathsFromStack(): void
+    {
+        $this->subject->push(self::CONFIGURATION_1);
+        $this->subject->push(self::CONFIGURATION_2);
+
+        self::assertSame(
+            [
+                10 => 'foo',
+                20 => 'another foo',
+                PHP_INT_MAX => 'another foo with higher priority',
+            ],
+            $this->subject->getTemplateRootPaths(),
+        );
+    }
+}


### PR DESCRIPTION
This PR introduces a new `HANDLEBARSTEMPLATE` content object. It accepts the following properties (like `FLUIDTEMPLATE`):

* `format`
* `templateName`
* `template`
* `file`
* `partialRootPath`
* `partialRootPaths`
* `templateRootPath`
* `templateRootPaths`
* `variables`
  - including `data` and `current` as reserved variables
  - allows simple hierarchy as well (`foo = bar` instead of `foo = TEXT` + `foo.value = bar`)
* `settings`
* `dataProcessing`
* `stdWrap`

In addition, the following properties are available:

* `headerAssets`
* `footerAssets`