### PR TITLE
[BUGFIX] Allow any type of rendering context in HelperContext

### DIFF
--- a/Classes/Renderer/Helper/BlockHelper.php
+++ b/Classes/Renderer/Helper/BlockHelper.php
@@ -41,6 +41,7 @@ final readonly class BlockHelper implements Helper
     public function render(Context\HelperContext $context): string
     {
         $name = $context[0];
+        /** @var array<string, mixed> $renderingContext */
         $renderingContext = $context->renderingContext;
         $actions = $renderingContext['_layoutActions'] ?? [];
         $stack = $renderingContext['_layoutStack'] ?? [];

--- a/Classes/Renderer/Helper/ContentHelper.php
+++ b/Classes/Renderer/Helper/ContentHelper.php
@@ -82,6 +82,7 @@ final readonly class ContentHelper implements Helper
      */
     private function getLayoutStack(Context\HelperContext $context): array
     {
+        /** @var array<string, mixed> $renderingContext */
         $renderingContext = $context->renderingContext;
         $contextStack = $context->contextStack;
 

--- a/Classes/Renderer/Helper/Context/HelperContext.php
+++ b/Classes/Renderer/Helper/Context/HelperContext.php
@@ -36,7 +36,6 @@ final class HelperContext implements \ArrayAccess
     /**
      * @param list<mixed> $arguments
      * @param array<string, mixed> $hash
-     * @param array<string, mixed> $renderingContext
      * @param array<'root'|int, array<string, mixed>> $data
      * @param callable|null $childrenClosure
      * @param callable|null $inverseClosure
@@ -45,7 +44,7 @@ final class HelperContext implements \ArrayAccess
         public readonly array $arguments, // 1...n-1
         public readonly array $hash, // n['hash']
         public readonly RenderingContextStack $contextStack, // n['contexts']
-        public array &$renderingContext, // n['_this']
+        public mixed &$renderingContext, // n['_this']
         public array &$data, // n['data'] => 'root', ...
         private $childrenClosure = null, // n['fn']
         private $inverseClosure = null, // n['inverse']

--- a/Classes/Renderer/Helper/ExtendHelper.php
+++ b/Classes/Renderer/Helper/ExtendHelper.php
@@ -55,6 +55,7 @@ final readonly class ExtendHelper implements Helper
         $handlebarsLayout = new Renderer\Component\Layout\HandlebarsLayout($fn);
 
         // Add layout to layout stack
+        /** @var array<string, mixed> $renderingContext */
         $renderingContext = &$context->renderingContext;
         $renderingContext['_layoutStack'] ??= [];
         $renderingContext['_layoutStack'][] = $handlebarsLayout;


### PR DESCRIPTION
The rendering context, which is applied to `HelperContext`, reflects `this` in Handlebars and can therefore be of any type. For example, when iterating over query results, it is an object of `AbstractEntity`. Thus, the underlying type is now widened to allow any kind of variable.