### PR TITLE
[FEATURE] Introduce Handlebars view for Extbase context

### DIFF
--- a/Classes/Extbase/View/ExtbaseHandlebarsView.php
+++ b/Classes/Extbase/View/ExtbaseHandlebarsView.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "handlebars".
+ *
+ * Copyright (C) 2025 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace Fr\Typo3Handlebars\Extbase\View;
+
+use TYPO3\CMS\Core;
+use TYPO3\CMS\Extbase;
+use TYPO3\CMS\Frontend;
+use TYPO3Fluid\Fluid;
+
+/**
+ * ExtbaseHandlebarsView
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-2.0-or-later
+ */
+final class ExtbaseHandlebarsView implements Fluid\View\ViewInterface
+{
+    /**
+     * @param array<string, mixed> $contentObjectConfiguration
+     */
+    public function __construct(
+        private readonly Frontend\ContentObject\ContentObjectRenderer $contentObjectRenderer,
+        private readonly Core\TypoScript\TypoScriptService $typoScriptService,
+        private array $contentObjectConfiguration,
+    ) {}
+
+    public function assign(string $key, mixed $value): self
+    {
+        // Maintain TypoScript object structure
+        if (\is_array($value)) {
+            $key .= '.';
+            $value = $this->typoScriptService->convertPlainArrayToTypoScriptArray($value);
+        }
+
+        $this->contentObjectConfiguration['variables.'][$key] = $value;
+
+        return $this;
+    }
+
+    /**
+     * @param array<string, mixed> $values
+     */
+    public function assignMultiple(array $values): self
+    {
+        foreach ($values as $key => $value) {
+            $this->assign($key, $value);
+        }
+
+        return $this;
+    }
+
+    public function render(): string
+    {
+        return $this->contentObjectRenderer->cObjGetSingle('HANDLEBARSTEMPLATE', $this->contentObjectConfiguration);
+    }
+
+    /**
+     * @param array<string, mixed> $variables
+     */
+    public function renderSection($sectionName, array $variables = [], $ignoreUnknown = false): string
+    {
+        // This is a Fluid feature, sections are not available in Handlebars.
+        return '';
+    }
+
+    /**
+     * @param array<string, mixed> $variables
+     */
+    public function renderPartial($partialName, $sectionName, array $variables, $ignoreUnknown = false): string
+    {
+        // This is a Fluid feature, Handlebars renderer takes care of rendering partials.
+        return '';
+    }
+
+    public function setTemplateName(string $templateName): self
+    {
+        $this->contentObjectConfiguration['templateName'] = $templateName;
+
+        return $this;
+    }
+
+    public function setTemplateNameFromRequest(Extbase\Mvc\RequestInterface $request): self
+    {
+        return $this->setTemplateName(
+            $request->getControllerName() . '/' . $request->getControllerActionName(),
+        );
+    }
+}

--- a/Classes/Extbase/View/ExtbaseHandlebarsViewResolver.php
+++ b/Classes/Extbase/View/ExtbaseHandlebarsViewResolver.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "handlebars".
+ *
+ * Copyright (C) 2025 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace Fr\Typo3Handlebars\Extbase\View;
+
+use Psr\Container;
+use TYPO3\CMS\Core;
+use TYPO3\CMS\Extbase;
+use TYPO3\CMS\Frontend;
+use TYPO3Fluid\Fluid;
+
+/**
+ * ExtbaseHandlebarsViewResolver
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-2.0-or-later
+ */
+final class ExtbaseHandlebarsViewResolver extends Extbase\Mvc\View\GenericViewResolver
+{
+    private readonly Frontend\ContentObject\ContentObjectRenderer $contentObjectRenderer;
+
+    public function __construct(
+        Container\ContainerInterface $container,
+        private readonly Extbase\Configuration\ConfigurationManagerInterface $configurationManager,
+        private readonly Core\TypoScript\TypoScriptService $typoScriptService,
+    ) {
+        parent::__construct($container);
+
+        $this->contentObjectRenderer = $container->get(Frontend\ContentObject\ContentObjectRenderer::class);
+    }
+
+    public function resolve(
+        string $controllerObjectName,
+        string $actionName,
+        string $format,
+        bool $enableFallback = true,
+    ): Fluid\View\ViewInterface {
+        $handlebarsConfiguration = $this->resolveHandlebarsConfiguration($controllerObjectName, $actionName);
+
+        if ($handlebarsConfiguration !== null || !$enableFallback) {
+            return new ExtbaseHandlebarsView(
+                $this->contentObjectRenderer,
+                $this->typoScriptService,
+                $handlebarsConfiguration ?? [],
+            );
+        }
+
+        return parent::resolve($controllerObjectName, $actionName, $format);
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function resolveHandlebarsConfiguration(string $controllerObjectName, string $actionName): ?array
+    {
+        $configuration = $this->configurationManager->getConfiguration(
+            Extbase\Configuration\ConfigurationManagerInterface::CONFIGURATION_TYPE_FRAMEWORK,
+        );
+        $controllerAlias = $configuration['controllerConfiguration'][$controllerObjectName]['alias'] ?? null;
+
+        // Early return if controller is not properly registered
+        if (!is_string($controllerAlias)) {
+            return null;
+        }
+
+        $handlebarsConfiguration = $configuration['handlebars'] ?? null;
+        $defaultConfiguration = [
+            'templateName' => $controllerAlias . '/' . $actionName,
+        ];
+
+        // Early return if no handlebars configuration is available
+        if (!is_array($handlebarsConfiguration)) {
+            return $defaultConfiguration;
+        }
+
+        // HANDLEBARSTEMPLATE content object requires TypoScript configuration, so let's convert early
+        $typoScriptConfiguration = $this->typoScriptService->convertPlainArrayToTypoScriptArray($handlebarsConfiguration);
+
+        // Resolve template name from controller action
+        if (is_string($typoScriptConfiguration['templateName'] ?? null) &&
+            is_array($typoScriptConfiguration['templateName.'] ?? null)
+        ) {
+            // Inject custom fields to be referenced in TypoScript when resolving the
+            // template name, e.g. in combination with a CASE content object
+            $this->contentObjectRenderer->data['controllerName'] = $controllerAlias;
+            $this->contentObjectRenderer->data['controllerObjectName'] = $controllerObjectName;
+            $this->contentObjectRenderer->data['controllerAction'] = $actionName;
+            $this->contentObjectRenderer->data['controllerNameAndAction'] = $controllerAlias . '::' . $actionName;
+
+            try {
+                // Resolve template name based on the current controller action
+                $typoScriptConfiguration['templateName'] = $this->contentObjectRenderer->cObjGetSingle(
+                    $typoScriptConfiguration['templateName'],
+                    $typoScriptConfiguration['templateName.'],
+                );
+            } finally {
+                // Remove configuration which is solely responsible for template name resolving
+                unset(
+                    $typoScriptConfiguration['templateName.'],
+                    $this->contentObjectRenderer->data['controllerName'],
+                    $this->contentObjectRenderer->data['controllerObjectName'],
+                    $this->contentObjectRenderer->data['controllerAction'],
+                    $this->contentObjectRenderer->data['controllerNameAndAction'],
+                );
+            }
+        }
+
+        // Early return if no (valid) template name is given
+        if (empty($typoScriptConfiguration['templateName'])) {
+            return $defaultConfiguration;
+        }
+
+        return $typoScriptConfiguration;
+    }
+}

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -8,6 +8,7 @@ services:
     resource: '../Classes/*'
     exclude:
       - '../Classes/DependencyInjection/*'
+      - '../Classes/Extbase/View/ExtbaseHandlebarsView.php'
 
   Fr\Typo3Handlebars\Cache\Cache:
     alias: 'handlebars.cache'
@@ -31,6 +32,10 @@ services:
     class: TYPO3\CMS\Core\Cache\Frontend\FrontendInterface
     factory: ['@TYPO3\CMS\Core\Cache\CacheManager', 'getCache']
     arguments: ['handlebars']
+
+  # Extbase
+  TYPO3\CMS\Extbase\Mvc\View\ViewResolverInterface:
+    alias: 'Fr\Typo3Handlebars\Extbase\View\ExtbaseHandlebarsViewResolver'
 
 handlebars:
   variables: []

--- a/Tests/Unit/Extbase/View/ExtbaseHandlebarsViewResolverTest.php
+++ b/Tests/Unit/Extbase/View/ExtbaseHandlebarsViewResolverTest.php
@@ -1,0 +1,234 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "handlebars".
+ *
+ * Copyright (C) 2025 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace Fr\Typo3Handlebars\Tests\Unit\Extbase\View;
+
+use Fr\Typo3Handlebars as Src;
+use Fr\Typo3Handlebars\Tests;
+use PHPUnit\Framework;
+use Symfony\Component\DependencyInjection;
+use TYPO3\CMS\Core;
+use TYPO3\CMS\Frontend;
+use TYPO3\TestingFramework;
+
+/**
+ * ExtbaseHandlebarsViewResolverTest
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-2.0-or-later
+ */
+#[Framework\Attributes\CoversClass(Src\Extbase\View\ExtbaseHandlebarsViewResolver::class)]
+final class ExtbaseHandlebarsViewResolverTest extends TestingFramework\Core\Unit\UnitTestCase
+{
+    /**
+     * @var list<list<mixed>|null>
+     */
+    private array $cObjGetSingleCalls = [null];
+
+    private Frontend\ContentObject\ContentObjectRenderer&Framework\MockObject\MockObject $contentObjectRendererMock;
+    private Tests\Unit\Fixtures\Classes\DummyConfigurationManager $configurationManager;
+    private Src\Extbase\View\ExtbaseHandlebarsViewResolver $subject;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->contentObjectRendererMock = $this->createMock(Frontend\ContentObject\ContentObjectRenderer::class);
+
+        $container = new DependencyInjection\Container();
+        $container->set(Frontend\ContentObject\ContentObjectRenderer::class, $this->contentObjectRendererMock);
+        $container->set(Tests\Unit\Fixtures\Classes\DummyView::class, new Tests\Unit\Fixtures\Classes\DummyView());
+
+        $this->configurationManager = new Tests\Unit\Fixtures\Classes\DummyConfigurationManager();
+        $this->configurationManager->configuration = [
+            'controllerConfiguration' => [
+                'Vendor\\Controller\\FooController' => [
+                    'alias' => 'Foo',
+                ],
+            ],
+        ];
+
+        $this->subject = new Src\Extbase\View\ExtbaseHandlebarsViewResolver(
+            $container,
+            $this->configurationManager,
+            new Core\TypoScript\TypoScriptService(),
+        );
+        $this->subject->setDefaultViewClass(Tests\Unit\Fixtures\Classes\DummyView::class);
+    }
+
+    #[Framework\Attributes\Test]
+    public function resolveReturnsFallbackViewIfControllerIsUnknown(): void
+    {
+        self::assertInstanceOf(
+            Tests\Unit\Fixtures\Classes\DummyView::class,
+            $this->subject->resolve('Vendor\\Controller\\UnknownController', 'baz', 'hbs'),
+        );
+    }
+
+    #[Framework\Attributes\Test]
+    public function resolveReturnsHandlebarsViewWithDefaultConfigurationIfNoHandlebarsConfigurationIsAvailable(): void
+    {
+        $actual = $this->subject->resolve('Vendor\\Controller\\FooController', 'baz', 'hbs');
+
+        self::assertInstanceOf(Src\Extbase\View\ExtbaseHandlebarsView::class, $actual);
+
+        $this->expectContentObjectConfiguration(
+            'HANDLEBARSTEMPLATE',
+            [
+                'templateName' => 'Foo/baz',
+            ],
+        );
+
+        $actual->render();
+    }
+
+    #[Framework\Attributes\Test]
+    public function resolveReturnsHandlebarsViewWithProcessedTemplateName(): void
+    {
+        $this->configurationManager->configuration['handlebars'] = [
+            'templateName' => [
+                '_typoScriptNodeValue' => 'CASE',
+                'key' => [
+                    'field' => 'controllerActionName',
+                ],
+                'baz' => [
+                    '_typoScriptNodeValue' => 'TEXT',
+                    'value' => '@baz',
+                ],
+                'default' => '@not-found',
+            ],
+        ];
+
+        $this->expectContentObjectConfigurationCalls(2);
+
+        $this->expectContentObjectConfiguration(
+            'CASE',
+            [
+                'key.' => [
+                    'field' => 'controllerActionName',
+                ],
+                'baz' => 'TEXT',
+                'baz.' => [
+                    'value' => '@baz',
+                ],
+                'default' => '@not-found',
+            ],
+            '@baz',
+        );
+
+        $this->expectContentObjectConfiguration(
+            'HANDLEBARSTEMPLATE',
+            [
+                'templateName' => '@baz',
+            ],
+        );
+
+        $actual = $this->subject->resolve('Vendor\\Controller\\FooController', 'baz', 'hbs');
+
+        self::assertInstanceOf(Src\Extbase\View\ExtbaseHandlebarsView::class, $actual);
+
+        $actual->render();
+    }
+
+    #[Framework\Attributes\Test]
+    public function resolveReturnsHandlebarsViewWithDefaultConfigurationIfProcessedTemplateNameIsEmpty(): void
+    {
+        $this->configurationManager->configuration['handlebars'] = [
+            'templateName' => [
+                '_typoScriptNodeValue' => 'CASE',
+                'key' => [
+                    'field' => 'controllerActionName',
+                ],
+                'boo' => [
+                    '_typoScriptNodeValue' => 'TEXT',
+                    'value' => '@boo',
+                ],
+            ],
+        ];
+
+        $this->expectContentObjectConfigurationCalls(2);
+        $this->expectContentObjectConfiguration(
+            'CASE',
+            [
+                'key.' => [
+                    'field' => 'controllerActionName',
+                ],
+                'boo' => 'TEXT',
+                'boo.' => [
+                    'value' => '@boo',
+                ],
+            ],
+            '',
+        );
+        $this->expectContentObjectConfiguration(
+            'HANDLEBARSTEMPLATE',
+            [
+                'templateName' => 'Foo/baz',
+            ],
+        );
+
+        $actual = $this->subject->resolve('Vendor\\Controller\\FooController', 'baz', 'hbs');
+
+        self::assertInstanceOf(Src\Extbase\View\ExtbaseHandlebarsView::class, $actual);
+
+        $actual->render();
+    }
+
+    /**
+     * @param array<string, mixed> $contentObjectConfiguration
+     */
+    private function expectContentObjectConfiguration(
+        string $contentObjectName,
+        array $contentObjectConfiguration,
+        string $return = '',
+    ): void {
+        $nextKey = null;
+        $count = count($this->cObjGetSingleCalls);
+
+        foreach ($this->cObjGetSingleCalls as $key => $call) {
+            if ($call === null) {
+                $nextKey = $key;
+                break;
+            }
+        }
+
+        if ($nextKey === null) {
+            self::fail('No more calls to cObjGetSingle expected.');
+        }
+
+        $this->cObjGetSingleCalls[$nextKey] = [$contentObjectName, $contentObjectConfiguration, $return];
+
+        if ($nextKey === $count - 1) {
+            $this->contentObjectRendererMock->expects(self::exactly($count))
+                ->method('cObjGetSingle')
+                /* @phpstan-ignore argument.type */
+                ->willReturnMap($this->cObjGetSingleCalls)
+            ;
+        }
+    }
+
+    private function expectContentObjectConfigurationCalls(int $count): void
+    {
+        $this->cObjGetSingleCalls = array_fill(0, $count, null);
+    }
+}

--- a/Tests/Unit/Extbase/View/ExtbaseHandlebarsViewTest.php
+++ b/Tests/Unit/Extbase/View/ExtbaseHandlebarsViewTest.php
@@ -1,0 +1,176 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "handlebars".
+ *
+ * Copyright (C) 2025 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace Fr\Typo3Handlebars\Tests\Unit\Extbase\View;
+
+use Fr\Typo3Handlebars as Src;
+use PHPUnit\Framework;
+use TYPO3\CMS\Core;
+use TYPO3\CMS\Extbase;
+use TYPO3\CMS\Frontend;
+use TYPO3\TestingFramework;
+
+/**
+ * ExtbaseHandlebarsViewTest
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-2.0-or-later
+ */
+#[Framework\Attributes\CoversClass(Src\Extbase\View\ExtbaseHandlebarsView::class)]
+final class ExtbaseHandlebarsViewTest extends TestingFramework\Core\Unit\UnitTestCase
+{
+    private Frontend\ContentObject\ContentObjectRenderer&Framework\MockObject\MockObject $contentObjectRendererMock;
+    private Src\Extbase\View\ExtbaseHandlebarsView $subject;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->contentObjectRendererMock = $this->createMock(Frontend\ContentObject\ContentObjectRenderer::class);
+        $this->subject = new Src\Extbase\View\ExtbaseHandlebarsView(
+            $this->contentObjectRendererMock,
+            new Core\TypoScript\TypoScriptService(),
+            [
+                'templateName' => '@foo',
+            ],
+        );
+    }
+
+    #[Framework\Attributes\Test]
+    public function assignAssignsSimpleVariableToContentObjectConfiguration(): void
+    {
+        $this->subject->assign('foo', 'baz');
+
+        $this->expectContentObjectConfiguration([
+            'variables.' => [
+                'foo' => 'baz',
+            ],
+        ]);
+
+        $this->subject->render();
+    }
+
+    #[Framework\Attributes\Test]
+    public function assignAssignsArrayVariableToContentObjectConfiguration(): void
+    {
+        $this->subject->assign('foo', [
+            'baz' => [
+                'bar' => 'hello world',
+            ],
+        ]);
+
+        $this->expectContentObjectConfiguration([
+            'variables.' => [
+                'foo.' => [
+                    'baz.' => [
+                        'bar' => 'hello world',
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->subject->render();
+    }
+
+    #[Framework\Attributes\Test]
+    public function assignMultipleAssignsAllVariablesToContentObjectConfiguration(): void
+    {
+        $this->subject->assignMultiple([
+            'baz' => 'foo',
+            'foo' => 'baz',
+        ]);
+
+        $this->expectContentObjectConfiguration([
+            'variables.' => [
+                'baz' => 'foo',
+                'foo' => 'baz',
+            ],
+        ]);
+
+        $this->subject->render();
+    }
+
+    #[Framework\Attributes\Test]
+    public function renderRendersHandlebarsTemplateContentObjectWithContentObjectConfiguration(): void
+    {
+        $this->expectContentObjectConfiguration(return: 'foo');
+
+        self::assertSame('foo', $this->subject->render());
+    }
+
+    #[Framework\Attributes\Test]
+    public function renderSectionReturnsEmptyString(): void
+    {
+        self::assertSame('', $this->subject->renderSection('foo'));
+    }
+
+    #[Framework\Attributes\Test]
+    public function renderPartialReturnsEmptyString(): void
+    {
+        self::assertSame('', $this->subject->renderPartial('foo', 'baz', []));
+    }
+
+    #[Framework\Attributes\Test]
+    public function setTemplateNameOverridesTemplateNameInContentObjectConfiguration(): void
+    {
+        $this->subject->setTemplateName('@baz');
+
+        $this->expectContentObjectConfiguration([
+            'templateName' => '@baz',
+        ]);
+
+        $this->subject->render();
+    }
+
+    #[Framework\Attributes\Test]
+    public function setTemplateNameFromRequestOverridesExtractedTemplateNameInContentObjectConfiguration(): void
+    {
+        $requestMock = $this->createMock(Extbase\Mvc\RequestInterface::class);
+        $requestMock->method('getControllerName')->willReturn('Foo');
+        $requestMock->method('getControllerActionName')->willReturn('Baz');
+
+        $this->subject->setTemplateNameFromRequest($requestMock);
+
+        $this->expectContentObjectConfiguration([
+            'templateName' => 'Foo/Baz',
+        ]);
+
+        $this->subject->render();
+    }
+
+    /**
+     * @param array<string, mixed> $contentObjectConfiguration
+     */
+    private function expectContentObjectConfiguration(array $contentObjectConfiguration = [], string $return = ''): void
+    {
+        if (!isset($contentObjectConfiguration['templateName'])) {
+            $contentObjectConfiguration['templateName'] = '@foo';
+        }
+
+        $this->contentObjectRendererMock->expects(self::once())
+            ->method('cObjGetSingle')
+            ->with('HANDLEBARSTEMPLATE', $contentObjectConfiguration)
+            ->willReturn($return)
+        ;
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
 	"require": {
 		"php": "~8.2.0 || ~8.3.0 || ~8.4.0",
 		"ext-json": "*",
+		"psr/container": "^1.0 || ^2.0",
 		"psr/event-dispatcher": "^1.0",
 		"psr/http-message": "^1.0 || ^2.0",
 		"psr/log": "^2.0 || ^3.0",
@@ -45,7 +46,7 @@
 		"phpstan/phpstan": "^1.9",
 		"phpstan/phpstan-phpunit": "^1.1",
 		"phpunit/phpcov": "^9.0 || ^10.0",
-		"phpunit/phpunit": "^10.1 || ^11.0",
+		"phpunit/phpunit": "^10.5 || ^11.0",
 		"saschaegerer/phpstan-typo3": "^1.0",
 		"ssch/typo3-rector": "^2.0",
 		"symfony/event-dispatcher": "^6.4 || ^7.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e71741f71386dcb30096e0094aa00647",
+    "content-hash": "c5f2e3e104c2fd3adb9d26391ebeadb5",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",


### PR DESCRIPTION
This PR introduces an `ExtbaseHandlebarsView` along with an `ExtbaseHandlebarsViewResolver`. Both are used for Extbase controllers to render a Handlebars template instead of a Fluid template.

### Usage for third-party controllers

For third-party controllers, Handlebars template rendering can be enabled by adding a dedicated TypoScript configuration to the plugin. Example:

```
plugin.tx_news {
  handlebars {
    templateName = CASE
    templateName {
      key.field = controllerNameAndAction

      News::list = TEXT
      News::list.value = @news-list

      default = @news
    }
  }
}
```

This renders the `news-list` Handlebars template for the News list action, all other actions will be rendered with the generic `news` Handlebars template.

If no `templateName` can be resolved (i.e., no `default` is given in the `CASE` cObj), the default view resolver is used (that means, in almost all cases a Fluid template is rendered).

### Usage for custom Handlebars controllers

Will follow in a separate PR.