### PR TITLE
[!!!][TASK] Migrate service configuration to attributes

### DIFF
--- a/Classes/Cache/HandlebarsCache.php
+++ b/Classes/Cache/HandlebarsCache.php
@@ -26,11 +26,11 @@ use TYPO3\CMS\Core;
  * @author Elias Häußler <e.haeussler@familie-redlich.de>
  * @license GPL-2.0-or-later
  */
-#[DependencyInjection\Attribute\AsAlias('handlebars.cache')]
+#[DependencyInjection\Attribute\AsAlias(Cache::class)]
 final readonly class HandlebarsCache implements Cache
 {
     public function __construct(
-        #[DependencyInjection\Attribute\Autowire('@cache.handlebars')]
+        #[DependencyInjection\Attribute\Autowire(expression: 'service("TYPO3\\\\CMS\\\\Core\\\\Cache\\\\CacheManager").getCache("handlebars")')]
         private Core\Cache\Frontend\FrontendInterface $cache,
     ) {}
 

--- a/Classes/DependencyInjection/FeatureRegistrationPass.php
+++ b/Classes/DependencyInjection/FeatureRegistrationPass.php
@@ -51,9 +51,6 @@ final class FeatureRegistrationPass implements DependencyInjection\Compiler\Comp
         if ($this->isFeatureEnabled('renderHelper')) {
             $this->activateHelper('render', Renderer\Helper\RenderHelper::class);
         }
-        if ($this->isFeatureEnabled('flatTemplateResolver')) {
-            $this->activateFlatTemplateResolver();
-        }
     }
 
     /**
@@ -66,11 +63,6 @@ final class FeatureRegistrationPass implements DependencyInjection\Compiler\Comp
             'identifier' => $name,
             'method' => 'render',
         ]);
-    }
-
-    private function activateFlatTemplateResolver(): void
-    {
-        $this->container->getDefinition('handlebars.template_resolver')->setClass(Renderer\Template\FlatTemplateResolver::class);
     }
 
     private function isFeatureEnabled(string $featureName): bool

--- a/Classes/Frontend/ContentObject/HandlebarsTemplateContentObject.php
+++ b/Classes/Frontend/ContentObject/HandlebarsTemplateContentObject.php
@@ -19,6 +19,7 @@ namespace Fr\Typo3Handlebars\Frontend\ContentObject;
 
 use Fr\Typo3Handlebars\Exception;
 use Fr\Typo3Handlebars\Renderer;
+use Symfony\Component\DependencyInjection;
 use TYPO3\CMS\Core;
 use TYPO3\CMS\Frontend;
 
@@ -28,6 +29,7 @@ use TYPO3\CMS\Frontend;
  * @author Elias Häußler <e.haeussler@familie-redlich.de>
  * @license GPL-2.0-or-later
  */
+#[DependencyInjection\Attribute\AutoconfigureTag('frontend.contentobject', ['identifier' => 'HANDLEBARSTEMPLATE'])]
 final class HandlebarsTemplateContentObject extends Frontend\ContentObject\AbstractContentObject
 {
     public function __construct(

--- a/Classes/Renderer/HandlebarsRenderer.php
+++ b/Classes/Renderer/HandlebarsRenderer.php
@@ -34,19 +34,17 @@ use TYPO3\CMS\Frontend;
  * @author Elias Häußler <e.haeussler@familie-redlich.de>
  * @license GPL-2.0-or-later
  */
-#[DependencyInjection\Attribute\AsAlias('handlebars.renderer')]
+#[DependencyInjection\Attribute\AsAlias(Renderer::class)]
 #[DependencyInjection\Attribute\Autoconfigure(tags: ['handlebars.renderer'])]
 class HandlebarsRenderer implements Renderer
 {
     protected ?bool $debugMode = null;
 
     public function __construct(
-        #[DependencyInjection\Attribute\Autowire('@handlebars.cache')]
         protected readonly Cache\Cache $cache,
         protected readonly EventDispatcher\EventDispatcherInterface $eventDispatcher,
         protected readonly Helper\HelperRegistry $helperRegistry,
         protected readonly Log\LoggerInterface $logger,
-        #[DependencyInjection\Attribute\Autowire('@handlebars.template_resolver')]
         protected readonly Template\TemplateResolver $templateResolver,
         protected readonly Variables\VariableBag $variableBag,
     ) {}

--- a/Classes/Renderer/Template/FlatTemplateResolver.php
+++ b/Classes/Renderer/Template/FlatTemplateResolver.php
@@ -18,6 +18,7 @@ declare(strict_types=1);
 namespace Fr\Typo3Handlebars\Renderer\Template;
 
 use Fr\Typo3Handlebars\Exception;
+use Symfony\Component\DependencyInjection;
 use Symfony\Component\Finder;
 
 /**
@@ -27,6 +28,7 @@ use Symfony\Component\Finder;
  * @license GPL-2.0-or-later
  * @see https://fractal.build/guide/core-concepts/naming.html
  */
+#[DependencyInjection\Attribute\AsAlias(TemplateResolver::class)]
 final class FlatTemplateResolver extends BaseTemplateResolver
 {
     private const MAX_FILE_DEPTH = 30;

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -2,36 +2,12 @@ services:
   _defaults:
     autowire: true
     autoconfigure: true
-    public: false
 
   Fr\Typo3Handlebars\:
     resource: '../Classes/*'
     exclude:
       - '../Classes/DependencyInjection/*'
       - '../Classes/Extbase/View/ExtbaseHandlebarsView.php'
-
-  Fr\Typo3Handlebars\Cache\Cache:
-    alias: 'handlebars.cache'
-  Fr\Typo3Handlebars\Renderer\Renderer:
-    alias: 'handlebars.renderer'
-  Fr\Typo3Handlebars\Renderer\Template\TemplateResolver:
-    alias: 'handlebars.template_resolver'
-
-  # Content object
-  Fr\Typo3Handlebars\Frontend\ContentObject\HandlebarsTemplateContentObject:
-    tags:
-      - name: frontend.contentobject
-        identifier: 'HANDLEBARSTEMPLATE'
-
-  # Template
-  handlebars.template_resolver:
-    class: 'Fr\Typo3Handlebars\Renderer\Template\HandlebarsTemplateResolver'
-
-  # Cache
-  cache.handlebars:
-    class: TYPO3\CMS\Core\Cache\Frontend\FrontendInterface
-    factory: ['@TYPO3\CMS\Core\Cache\CacheManager', 'getCache']
-    arguments: ['handlebars']
 
 handlebars:
   variables: []

--- a/Tests/Unit/DependencyInjection/FeatureRegistrationPassTest.php
+++ b/Tests/Unit/DependencyInjection/FeatureRegistrationPassTest.php
@@ -47,7 +47,6 @@ final class FeatureRegistrationPassTest extends TestingFramework\Core\Unit\UnitT
         'contentHelper' => false,
         'extendHelper' => false,
         'renderHelper' => false,
-        'flatTemplateResolver' => false,
     ];
 
     #[Framework\Attributes\Test]
@@ -56,7 +55,6 @@ final class FeatureRegistrationPassTest extends TestingFramework\Core\Unit\UnitT
         $container = $this->buildContainer();
 
         self::assertSame([], $container->findTaggedServiceIds('handlebars.helper'));
-        self::assertNotInstanceOf(Src\Renderer\Template\FlatTemplateResolver::class, $container->get('handlebars.template_resolver'));
     }
 
     #[Framework\Attributes\Test]
@@ -77,29 +75,16 @@ final class FeatureRegistrationPassTest extends TestingFramework\Core\Unit\UnitT
     }
 
     #[Framework\Attributes\Test]
-    public function processActivatesEnabledTemplateResolvers(): void
-    {
-        $this->activatedFeatures['flatTemplateResolver'] = true;
-
-        $container = $this->buildContainer();
-
-        self::assertSame([], $container->findTaggedServiceIds('handlebars.helper'));
-        self::assertInstanceOf(Src\Renderer\Template\FlatTemplateResolver::class, $container->get('handlebars.template_resolver'));
-    }
-
-    #[Framework\Attributes\Test]
     public function processDoesNotActivateFeaturesIfExtensionConfigurationIsMissing(): void
     {
         unset($this->activatedFeatures['blockHelper']);
         unset($this->activatedFeatures['contentHelper']);
         unset($this->activatedFeatures['extendHelper']);
         unset($this->activatedFeatures['renderHelper']);
-        unset($this->activatedFeatures['flatTemplateResolver']);
 
         $container = $this->buildContainer();
 
         self::assertSame([], $container->findTaggedServiceIds('handlebars.helper'));
-        self::assertNotInstanceOf(Src\Renderer\Template\FlatTemplateResolver::class, $container->get('handlebars.template_resolver'));
     }
 
     /**

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -9,6 +9,3 @@ features.extendHelper.enable = 1
 
 # cat=helpers/enable/40; type=boolean; label=Render helper: Enable globally (applies to the default Handlebars renderer)
 features.renderHelper.enable = 1
-
-# cat=template/enable/10; type=boolean; label=Flat template resolver: Enable globally (applies to the default Handlebars renderer)
-features.flatTemplateResolver.enable = 0


### PR DESCRIPTION
Remaining configuration in `Services.yaml` is now migrated to attributes. In addition, the `FlatTemplateResolver` is now the default template resolver, since it is also compatible with (?= falls back to) `HandlebarsTemplateResolver`.