### PR TITLE
[FEATURE] Support absolute template paths in template resolvers

### DIFF
--- a/Classes/Renderer/Template/BaseTemplateResolver.php
+++ b/Classes/Renderer/Template/BaseTemplateResolver.php
@@ -18,6 +18,7 @@ declare(strict_types=1);
 namespace Fr\Typo3Handlebars\Renderer\Template;
 
 use Fr\Typo3Handlebars\Exception;
+use Symfony\Component\Filesystem;
 use TYPO3\CMS\Core;
 
 /**
@@ -42,7 +43,9 @@ abstract class BaseTemplateResolver implements TemplateResolver
 
     protected function resolveFilename(string $path, ?string $rootPath = null, ?string $extension = null): string
     {
-        if ($rootPath !== null) {
+        if (Filesystem\Path::isAbsolute($path)) {
+            $filename = $path;
+        } elseif ($rootPath !== null) {
             $filename = $rootPath . DIRECTORY_SEPARATOR . ltrim($path, DIRECTORY_SEPARATOR);
         } else {
             $filename = $path;

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
 		"psr/log": "^3.0",
 		"symfony/config": "^7.0",
 		"symfony/dependency-injection": "^7.0",
+		"symfony/filesystem": "^7.0",
 		"symfony/finder": "^7.0",
 		"typo3/cms-core": "~13.4.0",
 		"typo3/cms-extbase": "~13.4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4b9f62aff50e524c19706b544cb1de83",
+    "content-hash": "099bead93ba90d99dca138e66d5b4729",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",


### PR DESCRIPTION
When resolving template paths via `TemplateResolver`, absolute paths can now be resolved as well.