### PR TITLE
[FEATURE] Introduce possibility to unflatten variable names

### DIFF
--- a/Classes/Frontend/ContentObject/HandlebarsTemplateContentObject.php
+++ b/Classes/Frontend/ContentObject/HandlebarsTemplateContentObject.php
@@ -138,6 +138,11 @@ final class HandlebarsTemplateContentObject extends Frontend\ContentObject\Abstr
             $variables = $this->contentDataProcessor->process($this->cObj, $config, $variables);
         }
 
+        // Convert flat variables (foo.bar.baz = xxx) to its multidimensional array representation (foo { bar { baz = xxx }}})
+        if ((int)($config['unflattenVariableNames'] ?? 0) === 1) {
+            $variables = Core\Utility\ArrayUtility::unflatten($variables);
+        }
+
         // Make settings available as variables
         if (isset($config['settings.'])) {
             $variables['settings'] = $this->typoScriptService->convertTypoScriptArrayToPlainArray($config['settings.']);

--- a/Tests/Functional/Frontend/ContentObject/HandlebarsTemplateContentObjectTest.php
+++ b/Tests/Functional/Frontend/ContentObject/HandlebarsTemplateContentObjectTest.php
@@ -373,6 +373,28 @@ final class HandlebarsTemplateContentObjectTest extends TestingFramework\Core\Fu
     }
 
     #[Framework\Attributes\Test]
+    public function renderUnflattensVariableNames(): void
+    {
+        $expected = [
+            'data' => [],
+            'current' => null,
+            'foo' => [
+                'baz' => 'boo',
+            ],
+        ];
+
+        $this->subject->render([
+            'template' => 'foo',
+            'variables.' => [
+                'foo.baz' => 'boo',
+            ],
+            'unflattenVariableNames' => '1',
+        ]);
+
+        self::assertEquals($expected, $this->renderer->lastContext?->getVariables());
+    }
+
+    #[Framework\Attributes\Test]
     public function renderResolvesAndAppliesSettingsFromConfig(): void
     {
         $expected = [


### PR DESCRIPTION
A new content object configuration option `unflattenVariableNames` is introduced. It can be used to unflatten variables like `foo.baz.boo` to its multidimensional array representation.

## Example

TypoScript:

```
lib.foo = HANDLEBARSTEMPLATE
lib.foo {
  # ...

  dataProcessing {
    10 = menu
    10 {
      # ...

      as = foo.baz.boo
    }
  }

  unflattenVariableNames = 1
}
```

Resulting variables:

```
foo {
  baz {
    boo = # Processed menu variables
  }
}
```