### PR TITLE
[FEATURE] Use generic `removeIf` config instead of `removeIfEmpty`

### DIFF
--- a/Classes/Frontend/ContentObject/HandlebarsTemplateContentObject.php
+++ b/Classes/Frontend/ContentObject/HandlebarsTemplateContentObject.php
@@ -244,16 +244,30 @@ final class HandlebarsTemplateContentObject extends Frontend\ContentObject\Abstr
             }
 
             $cObjConf = $variablesToProcess[$variableName . '.'] ?? [];
-
-            // Check if empty value should *not* be applied after processing
-            $removeIfEmpty = (int)($cObjConf['removeIfEmpty'] ?? 0) === 1;
-            unset($cObjConf['removeIfEmpty']);
+            $removeCondition = $cObjConf['removeIf.'] ?? null;
+            unset($cObjConf['removeIf.']);
 
             // Process value
             $value = $this->cObj->cObjGetSingle($cObjType, $cObjConf, 'variables.' . $variableName);
 
+            // Check if empty value should *not* be applied after processing
+            if (\is_array($removeCondition)) {
+                // Use processed value as current value
+                $currentValue = $this->cObj->getCurrentVal();
+                $this->cObj->setCurrentVal($value);
+
+                try {
+                    $removeVariable = $this->cObj->checkIf($removeCondition);
+                } finally {
+                    // Restore original current value
+                    $this->cObj->setCurrentVal($currentValue);
+                }
+            } else {
+                $removeVariable = false;
+            }
+
             // Apply value if not empty or no *empty toggle* is set
-            if (!$removeIfEmpty || trim($value) !== '') {
+            if (!$removeVariable || trim($value) !== '') {
                 $variables[$variableName] = $value;
             }
         }

--- a/Tests/Functional/Frontend/ContentObject/HandlebarsTemplateContentObjectTest.php
+++ b/Tests/Functional/Frontend/ContentObject/HandlebarsTemplateContentObjectTest.php
@@ -314,10 +314,12 @@ final class HandlebarsTemplateContentObjectTest extends TestingFramework\Core\Fu
     }
 
     #[Framework\Attributes\Test]
-    public function renderDoesNotApplyEmptyVariablesOnDefinedRemoveIfEmptyConfig(): void
+    public function renderDoesNotApplyEmptyVariablesOnDefinedRemoveIfConfig(): void
     {
         $expected = [
-            'data' => [],
+            'data' => [
+                $this->contentObjectRenderer->currentValKey => null,
+            ],
             'current' => null,
             'foo' => [],
         ];
@@ -329,7 +331,11 @@ final class HandlebarsTemplateContentObjectTest extends TestingFramework\Core\Fu
                     'baz' => 'TEXT',
                     'baz.' => [
                         'value' => '',
-                        'removeIfEmpty' => '1',
+                        'removeIf.' => [
+                            'isFalse.' => [
+                                'current' => '1',
+                            ],
+                        ],
                     ],
                 ],
             ],


### PR DESCRIPTION
This PR replaces the very specific `removeIfEmpty` configuration with a more generic `removeIf` configuration, which accepts all [stdWrap.if](https://docs.typo3.org/m/typo3/reference-typoscript/main/en-us/Functions/If.html) configuration options. If a condition matches, the variable is not applied/removed. The currently processed value is temporarily available as [`current`](https://docs.typo3.org/m/typo3/reference-typoscript/main/en-us/Functions/Stdwrap.html#confval-stdwrap-current) value.

Existing `removeIfEmpty` configurations must be migrated like follows:

```diff
-removeIfEmpty = 1
+removeIf.isFalse.current = 1
```

/cc @rpflamm 