### PR TITLE
[FEATURE] Extend `removeIf` support to simple variables

### DIFF
--- a/Classes/Frontend/ContentObject/HandlebarsTemplateContentObject.php
+++ b/Classes/Frontend/ContentObject/HandlebarsTemplateContentObject.php
@@ -197,10 +197,10 @@ final class HandlebarsTemplateContentObject extends Frontend\ContentObject\Abstr
 
             // Apply variable as simple variable if it's a simple construct
             // (including arrays, which will be processed recursively as they may contain content objects)
-            if (\is_array($value)) {
-                $simpleVariables[$sanitizedName] = $this->processVariables($value);
-            } else {
+            if (!\is_array($value)) {
                 $simpleVariables[$sanitizedName] = $value;
+            } elseif (!$this->shouldRemoveVariable($value)) {
+                $simpleVariables[$sanitizedName] = $this->processVariables($value);
             }
         }
 
@@ -244,27 +244,12 @@ final class HandlebarsTemplateContentObject extends Frontend\ContentObject\Abstr
             }
 
             $cObjConf = $variablesToProcess[$variableName . '.'] ?? [];
-            $removeCondition = $cObjConf['removeIf.'] ?? null;
-            unset($cObjConf['removeIf.']);
 
             // Process value
             $value = $this->cObj->cObjGetSingle($cObjType, $cObjConf, 'variables.' . $variableName);
 
-            // Check if empty value should *not* be applied after processing
-            if (\is_array($removeCondition)) {
-                // Use processed value as current value
-                $currentValue = $this->cObj->getCurrentVal();
-                $this->cObj->setCurrentVal($value);
-
-                try {
-                    $removeVariable = $this->cObj->checkIf($removeCondition);
-                } finally {
-                    // Restore original current value
-                    $this->cObj->setCurrentVal($currentValue);
-                }
-            } else {
-                $removeVariable = false;
-            }
+            // Check if value should *not* be applied after processing
+            $removeVariable = $this->shouldRemoveVariable($cObjConf, $value);
 
             // Apply value if not empty or no *empty toggle* is set
             if (!$removeVariable || trim($value) !== '') {
@@ -273,6 +258,34 @@ final class HandlebarsTemplateContentObject extends Frontend\ContentObject\Abstr
         }
 
         return $variables;
+    }
+
+    /**
+     * @param array<string, mixed> $configuration
+     */
+    private function shouldRemoveVariable(array $configuration, ?string $value = null): bool
+    {
+        if ($this->cObj === null) {
+            return false;
+        }
+
+        $removeCondition = $configuration['removeIf.'] ?? null;
+
+        // Early return on missing or insufficient remove condition
+        if (!\is_array($removeCondition)) {
+            return false;
+        }
+
+        // Use processed value as current value
+        $currentValue = $this->cObj->getCurrentVal();
+        $this->cObj->setCurrentVal($value);
+
+        try {
+            return $this->cObj->checkIf($removeCondition);
+        } finally {
+            // Restore original current value
+            $this->cObj->setCurrentVal($currentValue);
+        }
     }
 
     /**

--- a/Tests/Functional/Frontend/ContentObject/HandlebarsTemplateContentObjectTest.php
+++ b/Tests/Functional/Frontend/ContentObject/HandlebarsTemplateContentObjectTest.php
@@ -314,7 +314,7 @@ final class HandlebarsTemplateContentObjectTest extends TestingFramework\Core\Fu
     }
 
     #[Framework\Attributes\Test]
-    public function renderDoesNotApplyEmptyVariablesOnDefinedRemoveIfConfig(): void
+    public function renderDoesNotApplyContentObjectVariablesOnMatchingRemoveIfConfig(): void
     {
         $expected = [
             'data' => [
@@ -335,6 +335,43 @@ final class HandlebarsTemplateContentObjectTest extends TestingFramework\Core\Fu
                             'isFalse.' => [
                                 'current' => '1',
                             ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        self::assertEquals($expected, $this->renderer->lastContext?->getVariables());
+    }
+
+    #[Framework\Attributes\Test]
+    public function renderDoesNotApplySimpleVariablesOnMatchingRemoveIfConfig(): void
+    {
+        $this->contentObjectRenderer->data = [
+            'foo' => '',
+        ];
+
+        $expected = [
+            'data' => [
+                $this->contentObjectRenderer->currentValKey => null,
+                'foo' => '',
+            ],
+            'current' => null,
+        ];
+
+        $this->subject->render([
+            'template' => 'foo',
+            'variables.' => [
+                'foo.' => [
+                    'baz.' => [
+                        'foo' => 'TEXT',
+                        'foo.' => [
+                            'field' => 'foo',
+                        ],
+                    ],
+                    'removeIf.' => [
+                        'isFalse.' => [
+                            'field' => 'foo',
                         ],
                     ],
                 ],


### PR DESCRIPTION
The possibility to remove variables in the `HANDLEBARSTEMPLATE` content object by using the `removeIf` configuration has been extended to simple variables.


> [!NOTE]
> Other than for content objects, the `removeIf` configuration for simple variables does not contain the currently processed variable as `current` data in the content object renderer. This is due to a limitation in content object renderer that allows only strings as content for `stdWrap`.

**Example:**

```
lib.template = HANDLEBARSTEMPLATE
lib.template {
  variables {
    # This is a "simple variable"
    foo {
      baz = TEXT
      baz.field = my-field

      removeIf {
        isFalse.field = my-field
      }
    }
  }
}
```

**Result:**

If the `my-field` field is empty, the processed variables won't contain the `foo` object.