### PR TITLE
[FEATURE] Introduce data processor to replace markers in processed data

### DIFF
--- a/Classes/DataProcessing/ResolveMarkersProcessor.php
+++ b/Classes/DataProcessing/ResolveMarkersProcessor.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "handlebars".
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace CPSIT\Typo3Handlebars\DataProcessing;
+
+use CPSIT\Typo3Handlebars\Renderer;
+use Symfony\Component\DependencyInjection;
+use TYPO3\CMS\Frontend;
+
+/**
+ * Data processor to resolve and replace markers within configured variables.
+ *
+ * Example:
+ * ========
+ *
+ * lib {
+ *   navigation {
+ *     template = @nav
+ *     navData {
+ *       items = ###NAV_ITEMS###
+ *     }
+ *   }
+ * }
+ *
+ * page {
+ *   10 = HANDLEBARSTEMPLATE
+ *   10 {
+ *     templateName = @page
+ *     variables {
+ *       mainNav < lib.navigation
+ *     }
+ *
+ *     dataProcessing {
+ *       10 = menu
+ *       10.as = ###NAV_ITEMS###
+ *
+ *       90 = resolve-markers
+ *       90 {
+ *         removeNonMatchingMarkers = 1
+ *       }
+ *     }
+ *   }
+ * }
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-2.0-or-later
+ */
+#[DependencyInjection\Attribute\AutoconfigureTag('data.processor', ['identifier' => 'resolve-markers'])]
+final class ResolveMarkersProcessor implements Frontend\ContentObject\DataProcessorInterface
+{
+    /**
+     * @param array<string, mixed> $contentObjectConfiguration
+     * @param array<string, mixed> $processorConfiguration
+     * @param array<array-key, mixed> $processedData
+     * @return array<array-key, mixed>
+     */
+    public function process(
+        Frontend\ContentObject\ContentObjectRenderer $cObj,
+        array $contentObjectConfiguration,
+        array $processorConfiguration,
+        array $processedData,
+    ): array {
+        $pattern = $processorConfiguration['pattern'] ?? null;
+        $removeNonMatchingMarkers = (bool)($processorConfiguration['removeNonMatchingMarkers'] ?? false);
+
+        $processor = Renderer\Variables\MarkerBasedValueProcessor::create($pattern);
+        $processor->replaceMarkers($processedData, $removeNonMatchingMarkers);
+
+        return $processedData;
+    }
+}

--- a/Classes/Exception/MarkerPatternIsInvalid.php
+++ b/Classes/Exception/MarkerPatternIsInvalid.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "handlebars".
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace CPSIT\Typo3Handlebars\Exception;
+
+/**
+ * MarkerPatternIsInvalid
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-2.0-or-later
+ */
+final class MarkerPatternIsInvalid extends Exception
+{
+    public function __construct(string $markerPattern)
+    {
+        parent::__construct(
+            sprintf('The given string "%s" is not a valid marker pattern.', $markerPattern),
+            1762329551,
+        );
+    }
+}

--- a/Classes/Renderer/Variables/MarkerBasedValueProcessor.php
+++ b/Classes/Renderer/Variables/MarkerBasedValueProcessor.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "handlebars".
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace CPSIT\Typo3Handlebars\Renderer\Variables;
+
+use CPSIT\Typo3Handlebars\Exception;
+
+/**
+ * MarkerBasedValueProcessor
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-2.0-or-later
+ * @internal
+ */
+final class MarkerBasedValueProcessor
+{
+    private const DEFAULT_PATTERN = '/###(\w+)###/';
+
+    /**
+     * @var array<string, array<string, string|null>>
+     */
+    private static array $markerTemplateCache = [];
+
+    /**
+     * @var array<string, array{array<string, mixed>, string|int, mixed}>
+     */
+    private array $markerValues = [];
+
+    /**
+     * @var array<string, list<array{array<string, mixed>, string|int, mixed}>>
+     */
+    private array $replacementTargets = [];
+
+    /**
+     * @param non-empty-string $markerPattern
+     */
+    private function __construct(
+        private readonly string $markerPattern,
+    ) {
+        self::$markerTemplateCache[$this->markerPattern] ??= [];
+    }
+
+    /**
+     * @param non-empty-string|null $markerPattern
+     * @throws Exception\MarkerPatternIsInvalid
+     */
+    public static function create(?string $markerPattern = null): self
+    {
+        if ($markerPattern !== null && !self::isValidPattern($markerPattern)) {
+            throw new Exception\MarkerPatternIsInvalid($markerPattern);
+        }
+
+        return new self($markerPattern ?? self::DEFAULT_PATTERN);
+    }
+
+    private static function isValidPattern(string $markerPattern): bool
+    {
+        return @preg_match($markerPattern, '') !== false;
+    }
+
+    /**
+     * @param array<array-key, mixed> $values
+     */
+    public function replaceMarkers(array &$values, bool $removeNonMatchingMarkers = false): int
+    {
+        $this->collectReferencesRecursively($values);
+
+        $replacedMarkerValues = 0;
+
+        foreach ($this->replacementTargets as $marker => $targets) {
+            $removeTarget = false;
+
+            if (!isset($this->markerValues[$marker])) {
+                if ($removeNonMatchingMarkers) {
+                    $removeTarget = true;
+                } else {
+                    continue;
+                }
+            }
+
+            foreach ($targets as &$target) {
+                [&$targetParent, $targetKey, &$targetValue] = $target;
+
+                if ($removeTarget) {
+                    unset($targetParent[$targetKey]);
+                    continue;
+                }
+
+                [&$markerParent, $markerKey, $value] = $this->markerValues[$marker];
+                $targetValue = $value;
+                $replacedMarkerValues++;
+                unset($markerParent[$markerKey]);
+            }
+        }
+
+        return $replacedMarkerValues;
+    }
+
+    /**
+     * @param array<array-key, mixed> $values
+     */
+    private function collectReferencesRecursively(array &$values): void
+    {
+        foreach ($values as $key => &$value) {
+            $this->collectReferences($value, $key, $values);
+        }
+    }
+
+    /**
+     * @param array<array-key, mixed> $parent
+     */
+    private function collectReferences(mixed &$value, string|int $key, array &$parent): void
+    {
+        if (\is_array($value)) {
+            $this->collectReferencesRecursively($value);
+        }
+        if (\is_string($key) && ($marker = $this->resolveMarker($key)) !== null) {
+            $this->markerValues[$marker] = [&$parent, $key, $value];
+        }
+        if (\is_string($value) && ($marker = $this->resolveMarker($value)) !== null) {
+            $this->replacementTargets[$marker] ??= [];
+            $this->replacementTargets[$marker][] = [&$parent, $key, &$value];
+        }
+    }
+
+    private function resolveMarker(string $value): ?string
+    {
+        if (\array_key_exists($value, self::$markerTemplateCache[$this->markerPattern])) {
+            return self::$markerTemplateCache[$this->markerPattern][$value];
+        }
+
+        preg_match($this->markerPattern, $value, $matches);
+
+        return self::$markerTemplateCache[$this->markerPattern][$value] = $matches[1] ?? null;
+    }
+}

--- a/Tests/Functional/DataProcessing/ProcessVariablesProcessorTest.php
+++ b/Tests/Functional/DataProcessing/ProcessVariablesProcessorTest.php
@@ -57,7 +57,7 @@ final class ProcessVariablesProcessorTest extends TestingFramework\Core\Function
     }
 
     #[Framework\Attributes\Test]
-    public function processDoesNothingIGivenConditionDoesNotMatch(): void
+    public function processDoesNothingIfGivenConditionDoesNotMatch(): void
     {
         $this->contentObjectRenderer->data = [
             'foo' => '',

--- a/Tests/Functional/DataProcessing/ResolveMarkersProcessorTest.php
+++ b/Tests/Functional/DataProcessing/ResolveMarkersProcessorTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "handlebars".
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace CPSIT\Typo3Handlebars\Tests\Functional\DataProcessing;
+
+use CPSIT\Typo3Handlebars as Src;
+use CPSIT\Typo3Handlebars\Tests;
+use PHPUnit\Framework;
+use TYPO3\CMS\Extbase;
+use TYPO3\CMS\Frontend;
+use TYPO3\TestingFramework;
+
+/**
+ * ResolveMarkersProcessorTest
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-2.0-or-later
+ */
+#[Framework\Attributes\CoversClass(Src\DataProcessing\ResolveMarkersProcessor::class)]
+final class ResolveMarkersProcessorTest extends TestingFramework\Core\Functional\FunctionalTestCase
+{
+    use Tests\FrontendRequestTrait;
+
+    private Src\DataProcessing\ResolveMarkersProcessor $subject;
+    private Frontend\ContentObject\ContentObjectRenderer $contentObjectRenderer;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $request = $this->buildServerRequest();
+
+        $this->subject = new Src\DataProcessing\ResolveMarkersProcessor();
+        $this->contentObjectRenderer = new Frontend\ContentObject\ContentObjectRenderer();
+        $this->contentObjectRenderer->setRequest($request);
+        $this->get(Extbase\Configuration\ConfigurationManagerInterface::class)->setRequest($request);
+    }
+
+    #[Framework\Attributes\Test]
+    public function processAllowsOverwritingMarkerPattern(): void
+    {
+        $processorConfiguration = [
+            'pattern' => '/MARKER: (\w+)/',
+        ];
+        $processedData = [
+            'MARKER: foo' => 'baz',
+            'foo' => 'MARKER: foo',
+        ];
+
+        $expected = [
+            'foo' => 'baz',
+        ];
+
+        self::assertSame($expected, $this->subject->process($this->contentObjectRenderer, [], $processorConfiguration, $processedData));
+    }
+
+    #[Framework\Attributes\Test]
+    public function processDoesNotRemoveNonMatchingMarkersByDefault(): void
+    {
+        $processedData = [
+            '###BAZ###' => 'baz',
+            'foo' => '###FOO###',
+        ];
+
+        $expected = [
+            '###BAZ###' => 'baz',
+            'foo' => '###FOO###',
+        ];
+
+        self::assertSame($expected, $this->subject->process($this->contentObjectRenderer, [], [], $processedData));
+    }
+
+    #[Framework\Attributes\Test]
+    public function processAllowsToRemoveNonMatchingMarkers(): void
+    {
+        $processorConfiguration = [
+            'removeNonMatchingMarkers' => '1',
+        ];
+        $processedData = [
+            '###BAZ###' => 'baz',
+            'foo' => '###FOO###',
+        ];
+
+        $expected = [
+            '###BAZ###' => 'baz',
+        ];
+
+        self::assertSame($expected, $this->subject->process($this->contentObjectRenderer, [], $processorConfiguration, $processedData));
+    }
+
+    #[Framework\Attributes\Test]
+    public function processReturnsProcessedDataWithResolvedMarkers(): void
+    {
+        $processedData = [
+            '###BAZ###' => 'bar',
+            '###FOO###' => [
+                'baz' => '###BAZ###',
+            ],
+            'foo' => '###FOO###',
+        ];
+
+        $expected = [
+            'foo' => [
+                'baz' => 'bar',
+            ],
+        ];
+
+        self::assertSame($expected, $this->subject->process($this->contentObjectRenderer, [], [], $processedData));
+    }
+}

--- a/Tests/Unit/Renderer/Variables/MarkerBasedValueProcessorTest.php
+++ b/Tests/Unit/Renderer/Variables/MarkerBasedValueProcessorTest.php
@@ -1,0 +1,175 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "handlebars".
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace CPSIT\Typo3Handlebars\Tests\Unit\Renderer\Variables;
+
+use CPSIT\Typo3Handlebars as Src;
+use PHPUnit\Framework;
+use TYPO3\TestingFramework;
+
+/**
+ * MarkerBasedValueProcessorTest
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-2.0-or-later
+ */
+#[Framework\Attributes\CoversClass(Src\Renderer\Variables\MarkerBasedValueProcessor::class)]
+final class MarkerBasedValueProcessorTest extends TestingFramework\Core\Unit\UnitTestCase
+{
+    private Src\Renderer\Variables\MarkerBasedValueProcessor $subject;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->subject = Src\Renderer\Variables\MarkerBasedValueProcessor::create();
+    }
+
+    #[Framework\Attributes\Test]
+    public function createThrowsExceptionOnInvalidMarkerPattern(): void
+    {
+        $markerPattern = 'foo';
+
+        $this->expectExceptionObject(
+            new Src\Exception\MarkerPatternIsInvalid($markerPattern),
+        );
+
+        Src\Renderer\Variables\MarkerBasedValueProcessor::create($markerPattern);
+    }
+
+    #[Framework\Attributes\Test]
+    public function createAllowsToDefineCustomMarkerPattern(): void
+    {
+        $values = [
+            '%BAZ%' => [
+                'hello' => 'world',
+            ],
+            '%FOO%' => [
+                'foo' => [
+                    'baz' => '%BAZ%',
+                ],
+            ],
+            'hello' => [
+                'world' => '%FOO%',
+            ],
+        ];
+
+        $expected = [
+            'hello' => [
+                'world' => [
+                    'foo' => [
+                        'baz' => [
+                            'hello' => 'world',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $subject = Src\Renderer\Variables\MarkerBasedValueProcessor::create('/%(\w+)%/');
+
+        self::assertSame(2, $subject->replaceMarkers($values));
+        self::assertSame($expected, $values);
+    }
+
+    #[Framework\Attributes\Test]
+    public function replaceMarkersRecursivelyDetectsMarkers(): void
+    {
+        $values = [
+            '###BAZ###' => [
+                'hello' => 'world',
+            ],
+            '###FOO###' => [
+                'foo' => [
+                    'baz' => '###BAZ###',
+                ],
+            ],
+            'hello' => [
+                'world' => '###FOO###',
+            ],
+        ];
+
+        $expected = [
+            'hello' => [
+                'world' => [
+                    'foo' => [
+                        'baz' => [
+                            'hello' => 'world',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        self::assertSame(2, $this->subject->replaceMarkers($values));
+        self::assertSame($expected, $values);
+    }
+
+    #[Framework\Attributes\Test]
+    public function replaceMarkersKeepsNonMatchingMarkersByDefault(): void
+    {
+        $values = [
+            '###FOO###' => [
+                'foo' => [
+                    'baz' => '###BAZ###',
+                ],
+            ],
+            'hello' => [
+                'world' => '###FOO###',
+            ],
+        ];
+
+        $expected = [
+            'hello' => [
+                'world' => [
+                    'foo' => [
+                        'baz' => '###BAZ###',
+                    ],
+                ],
+            ],
+        ];
+
+        self::assertSame(1, $this->subject->replaceMarkers($values));
+        self::assertSame($expected, $values);
+    }
+
+    #[Framework\Attributes\Test]
+    public function replaceMarkersRemovesNonMatchingMarkersOnIntention(): void
+    {
+        $values = [
+            '###FOO###' => [
+                'foo' => [
+                    'baz' => '###BAZ###',
+                ],
+            ],
+            'hello' => [
+                'world' => '###FOO###',
+            ],
+        ];
+
+        $expected = [
+            'hello' => [
+                'world' => [
+                    'foo' => [],
+                ],
+            ],
+        ];
+
+        self::assertSame(1, $this->subject->replaceMarkers($values, true));
+        self::assertSame($expected, $values);
+    }
+}


### PR DESCRIPTION
This PR introduces a new `resolve-markers` data processor. It can be used to define references and replaces them with actual values at a later point of data processing, e.g. by using a dedicated data processor.

By default, the well-known marker pattern `###<MARKER-REFERENCE>###` is used. However, this can be configured by using the regex-based processor configuration `pattern`.

Example:

```
lib {
  navigation {
    template = @nav
    navData {
      items = ###NAV_ITEMS###
    }
  }
}

page {
  10 = HANDLEBARSTEMPLATE
  10 {
    templateName = @page
    variables {
      mainNav < lib.navigation
    }

    dataProcessing {
      10 = menu
      10.as = ###NAV_ITEMS###

      90 = resolve-markers
      90 {
        removeNonMatchingMarkers = 1
      }
    }
  }
}
```