### PR TITLE
[BUGFIX] Handle non-cacheable root paths in template resolving

### DIFF
--- a/Classes/Renderer/Template/HandlebarsTemplateResolver.php
+++ b/Classes/Renderer/Template/HandlebarsTemplateResolver.php
@@ -28,38 +28,79 @@ use CPSIT\Typo3Handlebars\Exception;
 final class HandlebarsTemplateResolver extends BaseTemplateResolver
 {
     /**
-     * @var list<string>
+     * @var array<string, list<string>>
      */
-    protected array $partialRootPaths = [];
-
-    /**
-     * @var list<string>
-     */
-    protected array $templateRootPaths = [];
+    private array $resolvedPaths = [];
 
     /**
      * @param string[] $supportedFileExtensions
-     * @throws Exception\RootPathIsMalicious
-     * @throws Exception\RootPathIsNotResolvable
      */
     public function __construct(
-        TemplatePaths $templatePaths,
+        private readonly TemplatePaths $templatePaths,
         array $supportedFileExtensions = self::DEFAULT_FILE_EXTENSIONS,
     ) {
-        [$this->templateRootPaths, $this->partialRootPaths] = $this->resolveTemplatePaths($templatePaths);
         $this->supportedFileExtensions = $this->resolveSupportedFileExtensions($supportedFileExtensions);
     }
 
+    /**
+     * @throws Exception\PartialPathIsNotResolvable
+     * @throws Exception\RootPathIsMalicious
+     * @throws Exception\RootPathIsNotResolvable
+     * @throws Exception\TemplateFormatIsNotSupported
+     */
     public function resolvePartialPath(string $partialPath, ?string $format = null): string
     {
-        return $this->resolvePath($partialPath, $this->partialRootPaths, $format)
+        return $this->resolvePath($partialPath, $this->resolvePartialRootPaths(), $format)
             ?? throw new Exception\PartialPathIsNotResolvable($partialPath, $format);
     }
 
+    /**
+     * @throws Exception\RootPathIsMalicious
+     * @throws Exception\RootPathIsNotResolvable
+     * @throws Exception\TemplateFormatIsNotSupported
+     * @throws Exception\TemplatePathIsNotResolvable
+     */
     public function resolveTemplatePath(string $templatePath, ?string $format = null): string
     {
-        return $this->resolvePath($templatePath, $this->templateRootPaths, $format)
+        return $this->resolvePath($templatePath, $this->resolveTemplateRootPaths(), $format)
             ?? throw new Exception\TemplatePathIsNotResolvable($templatePath, $format);
+    }
+
+    /**
+     * @return list<string>
+     * @throws Exception\RootPathIsMalicious
+     * @throws Exception\RootPathIsNotResolvable
+     */
+    private function resolvePartialRootPaths(): array
+    {
+        $partialRootPaths = $this->templatePaths->getPartialRootPaths();
+
+        return $this->resolveRootPathsFromCache($partialRootPaths);
+    }
+
+    /**
+     * @return list<string>
+     * @throws Exception\RootPathIsMalicious
+     * @throws Exception\RootPathIsNotResolvable
+     */
+    private function resolveTemplateRootPaths(): array
+    {
+        $templateRootPaths = $this->templatePaths->getTemplateRootPaths();
+
+        return $this->resolveRootPathsFromCache($templateRootPaths);
+    }
+
+    /**
+     * @param array<int, string> $rootPaths
+     * @return list<string>
+     * @throws Exception\RootPathIsMalicious
+     * @throws Exception\RootPathIsNotResolvable
+     */
+    private function resolveRootPathsFromCache(array $rootPaths): array
+    {
+        $hash = \sha1((string)\json_encode($rootPaths));
+
+        return $this->resolvedPaths[$hash] ?? ($this->resolvedPaths[$hash] = $this->normalizeRootPaths($rootPaths));
     }
 
     /**

--- a/Tests/Unit/Renderer/Template/HandlebarsTemplateResolverTest.php
+++ b/Tests/Unit/Renderer/Template/HandlebarsTemplateResolverTest.php
@@ -47,39 +47,6 @@ final class HandlebarsTemplateResolverTest extends TestingFramework\Core\Unit\Un
     }
 
     #[Framework\Attributes\Test]
-    public function constructorThrowsExceptionIfTemplateRootPathHasInvalidType(): void
-    {
-        $this->expectExceptionObject(
-            new Src\Exception\RootPathIsMalicious(null),
-        );
-
-        new Src\Renderer\Template\HandlebarsTemplateResolver(
-            new Src\Renderer\Template\TemplatePaths([
-                new Tests\Unit\Fixtures\Classes\Renderer\Template\Path\DummyPathProvider(
-                    /* @phpstan-ignore argument.type */
-                    [null],
-                ),
-            ]),
-        );
-    }
-
-    #[Framework\Attributes\Test]
-    public function constructorThrowsExceptionIfTemplateRootPathIsNotResolvable(): void
-    {
-        $this->expectExceptionObject(
-            new Src\Exception\RootPathIsNotResolvable('EXT:foo/baz'),
-        );
-
-        new Src\Renderer\Template\HandlebarsTemplateResolver(
-            new Src\Renderer\Template\TemplatePaths([
-                new Tests\Unit\Fixtures\Classes\Renderer\Template\Path\DummyPathProvider(
-                    ['EXT:foo/baz'],
-                ),
-            ]),
-        );
-    }
-
-    #[Framework\Attributes\Test]
     public function constructorThrowsExceptionIfFileExtensionHasInvalidType(): void
     {
         $this->expectExceptionObject(
@@ -98,6 +65,45 @@ final class HandlebarsTemplateResolverTest extends TestingFramework\Core\Unit\Un
         );
 
         new Src\Renderer\Template\HandlebarsTemplateResolver($this->getTemplatePaths(), ['foo?!']);
+    }
+
+    #[Framework\Attributes\Test]
+    public function resolvePartialPathThrowsExceptionIfRootPathHasInvalidType(): void
+    {
+        $subject = new Src\Renderer\Template\HandlebarsTemplateResolver(
+            new Src\Renderer\Template\TemplatePaths([
+                new Tests\Unit\Fixtures\Classes\Renderer\Template\Path\DummyPathProvider(
+                    [],
+                    /* @phpstan-ignore argument.type */
+                    [null],
+                ),
+            ]),
+        );
+
+        $this->expectExceptionObject(
+            new Src\Exception\RootPathIsMalicious(null),
+        );
+
+        $subject->resolvePartialPath('foo');
+    }
+
+    #[Framework\Attributes\Test]
+    public function resolvePartialPathThrowsExceptionIfRootPathIsNotResolvable(): void
+    {
+        $subject = new Src\Renderer\Template\HandlebarsTemplateResolver(
+            new Src\Renderer\Template\TemplatePaths([
+                new Tests\Unit\Fixtures\Classes\Renderer\Template\Path\DummyPathProvider(
+                    [],
+                    ['EXT:foo/baz'],
+                ),
+            ]),
+        );
+
+        $this->expectExceptionObject(
+            new Src\Exception\RootPathIsNotResolvable('EXT:foo/baz'),
+        );
+
+        $subject->resolvePartialPath('foo');
     }
 
     #[Framework\Attributes\Test]
@@ -143,6 +149,43 @@ final class HandlebarsTemplateResolverTest extends TestingFramework\Core\Unit\Un
         $expected = $this->partialRootPath . '/DummyPartial.hbs';
 
         self::assertSame($expected, $this->subject->resolvePartialPath($templatePath));
+    }
+
+    #[Framework\Attributes\Test]
+    public function resolveTemplatePathThrowsExceptionIfRootPathHasInvalidType(): void
+    {
+        $subject = new Src\Renderer\Template\HandlebarsTemplateResolver(
+            new Src\Renderer\Template\TemplatePaths([
+                new Tests\Unit\Fixtures\Classes\Renderer\Template\Path\DummyPathProvider(
+                    /* @phpstan-ignore argument.type */
+                    [null],
+                ),
+            ]),
+        );
+
+        $this->expectExceptionObject(
+            new Src\Exception\RootPathIsMalicious(null),
+        );
+
+        $subject->resolveTemplatePath('foo');
+    }
+
+    #[Framework\Attributes\Test]
+    public function resolveTemplatePathThrowsExceptionIfRootPathIsNotResolvable(): void
+    {
+        $subject = new Src\Renderer\Template\HandlebarsTemplateResolver(
+            new Src\Renderer\Template\TemplatePaths([
+                new Tests\Unit\Fixtures\Classes\Renderer\Template\Path\DummyPathProvider(
+                    ['EXT:foo/baz'],
+                ),
+            ]),
+        );
+
+        $this->expectExceptionObject(
+            new Src\Exception\RootPathIsNotResolvable('EXT:foo/baz'),
+        );
+
+        $subject->resolveTemplatePath('foo');
     }
 
     #[Framework\Attributes\Test]


### PR DESCRIPTION
Root paths from path providers may change during runtime, hence some of them are non-cacheable. This must be handled in the template resolver; root paths cannot be resolved once, but must be resolved on request (with additional cache layer).