### PR TITLE
[FEATURE] Introduce Fluid view helper invoker for Handlebars templates

### DIFF
--- a/Classes/Renderer/Helper/Fluid/ViewHelperInvoker.php
+++ b/Classes/Renderer/Helper/Fluid/ViewHelperInvoker.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "handlebars".
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace CPSIT\Typo3Handlebars\Renderer\Helper\Fluid;
+
+use CPSIT\Typo3Handlebars\Attribute;
+use CPSIT\Typo3Handlebars\Renderer;
+use DevTheorem\Handlebars;
+use Psr\Http\Message;
+use Psr\Log;
+use TYPO3\CMS\Fluid;
+
+/**
+ * ViewHelperInvoker
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-2.0-or-later
+ * @internal
+ */
+#[Attribute\AsHelper('viewHelper')]
+final readonly class ViewHelperInvoker implements Renderer\Helper\Helper
+{
+    public function __construct(
+        private Fluid\Core\Rendering\RenderingContextFactory $renderingContextFactory,
+        private Log\LoggerInterface $logger,
+    ) {}
+
+    public function render(
+        Handlebars\HelperOptions $options,
+        ?Renderer\RenderingContext $renderingContext = null,
+        string $name = '',
+    ): mixed {
+        if (!str_contains($name, ':')) {
+            $this->logger->error(
+                'Fluid ViewHelper invoker requires a valid combination of namespace and view helper shortname, e.g. "f:debug", "{name}" given.',
+                ['name' => $name],
+            );
+
+            return null;
+        }
+
+        $fluidRenderingContext = $this->renderingContextFactory->create();
+        $renderingContext ??= $options->data['renderingContext'] ?? null;
+        $request = null;
+
+        if ($renderingContext instanceof Renderer\RenderingContext) {
+            $request = $renderingContext->getRequest();
+        }
+
+        if ($request !== null) {
+            $fluidRenderingContext->setAttribute(Message\ServerRequestInterface::class, $request);
+        }
+
+        [$namespace, $viewHelperShortName] = \explode(':', $name, 2);
+        $className = $fluidRenderingContext->getViewHelperResolver()->createViewHelperInstance($namespace, $viewHelperShortName);
+
+        return $fluidRenderingContext->getViewHelperInvoker()->invoke($className, $options->hash, $fluidRenderingContext, $options->fn);
+    }
+}

--- a/Tests/Functional/Fixtures/Extensions/test_extension/Resources/Templates/viewHelper-invalid.hbs
+++ b/Tests/Functional/Fixtures/Extensions/test_extension/Resources/Templates/viewHelper-invalid.hbs
@@ -1,0 +1,1 @@
+{{viewHelper 'foo'}}

--- a/Tests/Functional/Fixtures/Extensions/test_extension/Resources/Templates/viewHelper.hbs
+++ b/Tests/Functional/Fixtures/Extensions/test_extension/Resources/Templates/viewHelper.hbs
@@ -1,0 +1,1 @@
+{{viewHelper 'f:join' value=array separator='.'}}

--- a/Tests/Functional/Renderer/Helper/Fluid/ViewHelperInvokerTest.php
+++ b/Tests/Functional/Renderer/Helper/Fluid/ViewHelperInvokerTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "handlebars".
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace CPSIT\Typo3Handlebars\Tests\Functional\Renderer\Helper\Fluid;
+
+use CPSIT\Typo3Handlebars as Src;
+use CPSIT\Typo3Handlebars\Tests;
+use PHPUnit\Framework;
+use Psr\Http\Message;
+use Psr\Log;
+use Symfony\Component\EventDispatcher;
+use TYPO3\CMS\Fluid;
+use TYPO3\TestingFramework;
+
+/**
+ * ViewHelperInvokerTest
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-2.0-or-later
+ */
+#[Framework\Attributes\CoversClass(Src\Renderer\Helper\Fluid\ViewHelperInvoker::class)]
+final class ViewHelperInvokerTest extends TestingFramework\Core\Functional\FunctionalTestCase
+{
+    use Tests\FrontendRequestTrait;
+    use Tests\HandlebarsTemplateResolverTrait;
+
+    protected array $testExtensionsToLoad = [
+        'handlebars',
+        'test_extension',
+    ];
+
+    private Log\Test\TestLogger $logger;
+    private Src\Renderer\HandlebarsRenderer $renderer;
+    private Message\ServerRequestInterface $request;
+
+    protected function setUp(): void
+    {
+        $this->allowAdditionalRootPaths();
+
+        parent::setUp();
+
+        $helperRegistry = new Src\Renderer\Helper\HelperRegistry(new Log\NullLogger());
+
+        $this->templateRootPath = 'EXT:test_extension/Resources/Templates/';
+        $this->logger = new Log\Test\TestLogger();
+        $this->templateResolver = new Src\Renderer\Template\FlatTemplateResolver($this->getTemplatePaths());
+        $this->renderer = new Src\Renderer\HandlebarsRenderer(
+            new Src\Cache\NullCache(),
+            new EventDispatcher\EventDispatcher(),
+            $helperRegistry,
+            $this->templateResolver,
+            new Src\Renderer\Variables\VariableBag([]),
+        );
+
+        $subject = new Src\Renderer\Helper\Fluid\ViewHelperInvoker(
+            $this->get(Fluid\Core\Rendering\RenderingContextFactory::class),
+            $this->logger,
+        );
+
+        $helperRegistry->add('viewHelper', $subject);
+
+        $this->request = $this->buildServerRequest();
+    }
+
+    #[Framework\Attributes\Test]
+    public function helperThrowsExceptionOnInvalidViewHelperName(): void
+    {
+        $this->renderer->render(
+            new Src\Renderer\RenderingContext('@viewHelper-invalid', [], $this->request),
+        );
+
+        self::assertTrue(
+            $this->logger->hasError([
+                'message' => 'Fluid ViewHelper invoker requires a valid combination of namespace and view helper shortname, e.g. "f:debug", "{name}" given.',
+                'context' => [
+                    'name' => 'foo',
+                ],
+            ])
+        );
+    }
+
+    #[Framework\Attributes\Test]
+    public function helperDelegatesRenderingToRequestedViewHelper(): void
+    {
+        $actual = $this->renderer->render(
+            new Src\Renderer\RenderingContext(
+                '@viewHelper',
+                [
+                    'array' => ['foo', 'baz'],
+                ],
+                $this->request,
+            ),
+        );
+
+        self::assertSame('foo.baz', trim($actual));
+    }
+}


### PR DESCRIPTION
This PR introduces a new Handlebars helper `viewHelper`. It can be used to trigger a configured Fluid view helper by referencing its full VH namespace.

Example:

```handlebars
{{viewHelper 'f:cObject' typoscriptObjectPath='lib.contentElement' data=data}}
```