### PR TITLE
[FEATURE] Extract `unflattenVariableNames` config to data processor

### DIFF
--- a/Classes/DataProcessing/UnflattenVariableNamesProcessor.php
+++ b/Classes/DataProcessing/UnflattenVariableNamesProcessor.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "handlebars".
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace CPSIT\Typo3Handlebars\DataProcessing;
+
+use Symfony\Component\DependencyInjection;
+use TYPO3\CMS\Core;
+use TYPO3\CMS\Frontend;
+
+/**
+ * Data processor to unflatten nested variable names, converting them from `foo.baz.bar` to `foo { baz { bar = ... }}`.
+ *
+ * Example
+ * =======
+ *
+ * page = HANDLEBARSTEMPLATE
+ * page {
+ *   templateName = @page
+ *
+ *   # ...
+ *
+ *   dataProcessing {
+ *     10 = menu
+ *     10 {
+ *       # ...
+ *
+ *       as = page.pageHeader.nav.mainMenu
+ *     }
+ *
+ *     20 = unflatten-variable-names
+ *   }
+ * }
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-2.0-or-later
+ */
+#[DependencyInjection\Attribute\AutoconfigureTag('data.processor', ['identifier' => 'unflatten-variable-names'])]
+final readonly class UnflattenVariableNamesProcessor implements Frontend\ContentObject\DataProcessorInterface
+{
+    /**
+     * @param array<string, mixed> $contentObjectConfiguration
+     * @param array<string, mixed> $processorConfiguration
+     * @param array<string, mixed> $processedData
+     * @return array<string, mixed>
+     */
+    public function process(
+        Frontend\ContentObject\ContentObjectRenderer $cObj,
+        array $contentObjectConfiguration,
+        array $processorConfiguration,
+        array $processedData,
+    ): array {
+        return Core\Utility\ArrayUtility::unflatten($processedData);
+    }
+}

--- a/Classes/Frontend/ContentObject/HandlebarsTemplateContentObject.php
+++ b/Classes/Frontend/ContentObject/HandlebarsTemplateContentObject.php
@@ -142,11 +142,6 @@ final class HandlebarsTemplateContentObject extends Frontend\ContentObject\Abstr
             $variables = $this->contentDataProcessor->process($this->cObj, $config, $variables);
         }
 
-        // Convert flat variables (foo.bar.baz = xxx) to its multidimensional array representation (foo { bar { baz = xxx }}})
-        if ((int)($config['unflattenVariableNames'] ?? 0) === 1) {
-            $variables = Core\Utility\ArrayUtility::unflatten($variables);
-        }
-
         // Make settings available as variables
         if (isset($config['settings.'])) {
             $variables['settings'] = $this->typoScriptService->convertTypoScriptArrayToPlainArray($config['settings.']);

--- a/Tests/Functional/DataProcessing/UnflattenVariableNamesProcessorTest.php
+++ b/Tests/Functional/DataProcessing/UnflattenVariableNamesProcessorTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "handlebars".
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace CPSIT\Typo3Handlebars\Tests\Functional\DataProcessing;
+
+use CPSIT\Typo3Handlebars as Src;
+use PHPUnit\Framework;
+use TYPO3\CMS\Frontend;
+use TYPO3\TestingFramework;
+
+/**
+ * UnflattenVariableNamesProcessorTest
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-2.0-or-later
+ */
+#[Framework\Attributes\CoversClass(Src\DataProcessing\UnflattenVariableNamesProcessor::class)]
+final class UnflattenVariableNamesProcessorTest extends TestingFramework\Core\Functional\FunctionalTestCase
+{
+    private Src\DataProcessing\UnflattenVariableNamesProcessor $subject;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->subject = new Src\DataProcessing\UnflattenVariableNamesProcessor();
+    }
+
+    #[Framework\Attributes\Test]
+    public function processUnflattensVariableNamesFromProcessedData(): void
+    {
+        $expected = [
+            'foo' => [
+                'baz' => 'boo',
+            ],
+        ];
+
+        $actual = $this->subject->process(
+            $this->createMock(Frontend\ContentObject\ContentObjectRenderer::class),
+            [],
+            [],
+            [
+                'foo.baz' => 'boo',
+            ],
+        );
+
+        self::assertSame($expected, $actual);
+    }
+}

--- a/Tests/Functional/Frontend/ContentObject/HandlebarsTemplateContentObjectTest.php
+++ b/Tests/Functional/Frontend/ContentObject/HandlebarsTemplateContentObjectTest.php
@@ -241,28 +241,6 @@ final class HandlebarsTemplateContentObjectTest extends TestingFramework\Core\Fu
     }
 
     #[Framework\Attributes\Test]
-    public function renderUnflattensVariableNames(): void
-    {
-        $expected = [
-            'data' => [],
-            'current' => null,
-            'foo' => [
-                'baz' => 'boo',
-            ],
-        ];
-
-        $this->subject->render([
-            'template' => 'foo',
-            'variables.' => [
-                'foo.baz' => 'boo',
-            ],
-            'unflattenVariableNames' => '1',
-        ]);
-
-        self::assertEquals($expected, $this->renderer->lastContext?->getVariables());
-    }
-
-    #[Framework\Attributes\Test]
     public function renderResolvesAndAppliesSettingsFromConfig(): void
     {
         $expected = [


### PR DESCRIPTION
## About this PR

This PR extracts the `HANDLEBARSTEMPLATE` configuration option `unflattenVariableNames` to a separate data processor `unflatten-variable-names`, keeping the cObj implementation closer to the `FLUIDTEMPLATE` implementation.

## Migration

Convert existing usages of `unflattenVariableNames` to use the dedicated data processor.

```diff
 page = HANDLEBARSTEMPLATE
 page {
   templateName = @page
   dataProcessing {
     10 = menu
     10 {
       # ...
       as = page.pageHeader.nav.mainMenu
     }
-  }
-  unflattenVariableNames = 1
+    20 = unflatten-variable-names
+  }
 }
```