### PR TITLE
[FEATURE] Allow various data sources in `process-variables` processor

### DIFF
--- a/Classes/DataProcessing/ProcessVariablesProcessor.php
+++ b/Classes/DataProcessing/ProcessVariablesProcessor.php
@@ -19,7 +19,9 @@ namespace CPSIT\Typo3Handlebars\DataProcessing;
 
 use CPSIT\Typo3Handlebars\Exception;
 use CPSIT\Typo3Handlebars\Renderer;
+use Psr\Log;
 use Symfony\Component\DependencyInjection;
+use TYPO3\CMS\Core;
 use TYPO3\CMS\Frontend;
 
 /**
@@ -96,6 +98,11 @@ use TYPO3\CMS\Frontend;
 #[DependencyInjection\Attribute\AutoconfigureTag('data.processor', ['identifier' => 'process-variables'])]
 final readonly class ProcessVariablesProcessor implements Frontend\ContentObject\DataProcessorInterface
 {
+    public function __construct(
+        private Log\LoggerInterface $logger,
+        private Core\TypoScript\TypoScriptService $typoScriptService,
+    ) {}
+
     /**
      * @param array<string, mixed> $contentObjectConfiguration
      * @param array<string, mixed> $processorConfiguration
@@ -110,7 +117,7 @@ final readonly class ProcessVariablesProcessor implements Frontend\ContentObject
         array $processorConfiguration,
         array $processedData,
     ): array {
-        $data = $processorConfiguration['data.'] ?? $processedData['data'] ?? $cObj->data;
+        $data = $this->resolveDataSources($contentObjectConfiguration, $processorConfiguration, $processedData, $cObj) ?? $cObj->data;
         $table = $processorConfiguration['table'] ?? $processedData['table'] ?? $cObj->getCurrentTable();
         $variables = $processorConfiguration['variables.'] ?? null;
         $as = $processorConfiguration['as'] ?? null;
@@ -142,5 +149,115 @@ final readonly class ProcessVariablesProcessor implements Frontend\ContentObject
         }
 
         return $processedData;
+    }
+
+    /**
+     * @param array<string, mixed> $contentObjectConfiguration
+     * @param array<string, mixed> $processorConfiguration
+     * @param array<string|int, mixed> $processedData
+     * @return array<string|int, mixed>|null
+     */
+    private function resolveDataSources(
+        array $contentObjectConfiguration,
+        array $processorConfiguration,
+        array $processedData,
+        Frontend\ContentObject\ContentObjectRenderer $contentObjectRenderer,
+    ): ?array {
+        /** @var array<string|int, mixed>|null $dataFromConfiguration */
+        $dataFromConfiguration = $processorConfiguration['data.'] ?? null;
+        /** @var array<string|int, mixed>|null $dataFromProcessedData */
+        $dataFromProcessedData = $processedData['data'] ?? null;
+        /** @var string|array<int, string>|null $dataSources */
+        $dataSources = $processorConfiguration['dataSource.'] ?? $processorConfiguration['dataSource'] ?? null;
+
+        // Early return if no data sources are configured
+        if ($dataSources === null) {
+            return $dataFromConfiguration ?? $dataFromProcessedData;
+        }
+
+        // Normalize content object configuration
+        $contentObjectConfiguration = $this->typoScriptService->convertTypoScriptArrayToPlainArray($contentObjectConfiguration);
+
+        // Normalize simplified data source configuration
+        if (!is_array($dataSources)) {
+            $dataSources = [$dataSources];
+        }
+
+        ksort($dataSources);
+
+        return array_reduce(
+            $dataSources,
+            fn(array $carry, string $keyword) => $this->processDataSource(
+                $carry,
+                $keyword,
+                $contentObjectConfiguration,
+                $contentObjectRenderer,
+                $processedData,
+            ),
+            [],
+        );
+    }
+
+    /**
+     * @param array<string|int, mixed> $processedDataSources
+     * @param array<string|int, mixed> $contentObjectConfiguration
+     * @param array<string|int, mixed> $processedData
+     * @return array<string|int, mixed>
+     */
+    private function processDataSource(
+        array $processedDataSources,
+        string $dataSourceIdentifier,
+        array $contentObjectConfiguration,
+        Frontend\ContentObject\ContentObjectRenderer $contentObjectRenderer,
+        array $processedData,
+    ): array {
+        if (str_contains($dataSourceIdentifier, ':')) {
+            [$dataSourceIdentifier, $path] = Core\Utility\GeneralUtility::trimExplode(':', $dataSourceIdentifier, true, 2);
+        } else {
+            $path = null;
+        }
+
+        $dataSource = ProcessorDataSource::tryFrom($dataSourceIdentifier);
+
+        if ($dataSource === null) {
+            $this->logger->warning(
+                'Invalid processor data source keyword "{source}" passed to "process-variables" data processor (while processing {table}:{uid}).',
+                [
+                    'source' => $dataSourceIdentifier,
+                    'table' => $contentObjectRenderer->getCurrentTable(),
+                    'uid' => $contentObjectRenderer->data['uid'] ?? '*unknown*',
+                ],
+            );
+        }
+
+        $data = match ($dataSource) {
+            ProcessorDataSource::ContentObjectConfiguration => $contentObjectConfiguration,
+            ProcessorDataSource::ContentObjectRenderer => $contentObjectRenderer->data,
+            ProcessorDataSource::ProcessedData => $processedData,
+            default => [],
+        };
+
+        // Limit data to configured path
+        if ($path !== null) {
+            try {
+                $data = Core\Utility\ArrayUtility::getValueByPath($data, $path, '.');
+            } catch (Core\Utility\Exception\MissingArrayPathException) {
+                $this->logger->warning(
+                    'Invalid path "{path}" for processor data source "{source}" passed to "process-variables" data processor (while processing {table}:{uid}).',
+                    [
+                        'path' => $path,
+                        'source' => $dataSourceIdentifier,
+                        'table' => $contentObjectRenderer->getCurrentTable(),
+                        'uid' => $contentObjectRenderer->data['uid'] ?? '*unknown*',
+                    ],
+                );
+
+                return $processedDataSources;
+            }
+        }
+
+        Core\Utility\ArrayUtility::mergeRecursiveWithOverrule($processedDataSources, $data);
+
+        return $processedDataSources;
     }
 }

--- a/Classes/DataProcessing/ProcessorDataSource.php
+++ b/Classes/DataProcessing/ProcessorDataSource.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "handlebars".
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace CPSIT\Typo3Handlebars\DataProcessing;
+
+/**
+ * ProcessorDataSource
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-2.0-or-later
+ */
+enum ProcessorDataSource: string
+{
+    case ContentObjectConfiguration = 'contentObjectConfiguration';
+    case ContentObjectRenderer = 'contentObjectRenderer';
+    case ProcessedData = 'processedData';
+}

--- a/Tests/Functional/DataProcessing/ProcessVariablesProcessorTest.php
+++ b/Tests/Functional/DataProcessing/ProcessVariablesProcessorTest.php
@@ -20,6 +20,8 @@ namespace CPSIT\Typo3Handlebars\Tests\Functional\DataProcessing;
 use CPSIT\Typo3Handlebars as Src;
 use CPSIT\Typo3Handlebars\Tests;
 use PHPUnit\Framework;
+use Psr\Log;
+use TYPO3\CMS\Core;
 use TYPO3\CMS\Extbase;
 use TYPO3\CMS\Frontend;
 use TYPO3\TestingFramework;
@@ -35,6 +37,7 @@ final class ProcessVariablesProcessorTest extends TestingFramework\Core\Function
 {
     use Tests\FrontendRequestTrait;
 
+    private Log\Test\TestLogger $logger;
     private Src\DataProcessing\ProcessVariablesProcessor $subject;
     private Frontend\ContentObject\ContentObjectRenderer $contentObjectRenderer;
 
@@ -44,7 +47,11 @@ final class ProcessVariablesProcessorTest extends TestingFramework\Core\Function
 
         $request = $this->buildServerRequest();
 
-        $this->subject = new Src\DataProcessing\ProcessVariablesProcessor();
+        $this->logger = new Log\Test\TestLogger();
+        $this->subject = new Src\DataProcessing\ProcessVariablesProcessor(
+            $this->logger,
+            new Core\TypoScript\TypoScriptService(),
+        );
         $this->contentObjectRenderer = new Frontend\ContentObject\ContentObjectRenderer();
         $this->contentObjectRenderer->setRequest($request);
         $this->get(Extbase\Configuration\ConfigurationManagerInterface::class)->setRequest($request);
@@ -54,6 +61,255 @@ final class ProcessVariablesProcessorTest extends TestingFramework\Core\Function
     public function processDoesNothingIfNoVariablesAreConfigured(): void
     {
         self::assertSame([], $this->subject->process($this->contentObjectRenderer, [], [], []));
+    }
+
+    #[Framework\Attributes\Test]
+    public function processUsesConfiguredDataIfNoDataSourcesAreDefined(): void
+    {
+        $processorConfiguration = [
+            'data.' => [
+                'foo' => 'baz',
+            ],
+            'variables.' => [
+                'foo' => 'TEXT',
+                'foo.' => [
+                    'field' => 'foo',
+                ],
+            ],
+        ];
+
+        $expected = [
+            'foo' => 'baz',
+        ];
+
+        self::assertSame($expected, $this->subject->process($this->contentObjectRenderer, [], $processorConfiguration, []));
+    }
+
+    #[Framework\Attributes\Test]
+    public function processUsesDataFromProcessedDataIfNoDataSourcesAreDefined(): void
+    {
+        $processorConfiguration = [
+            'variables.' => [
+                'foo' => 'TEXT',
+                'foo.' => [
+                    'field' => 'foo',
+                ],
+            ],
+        ];
+        $processedData = [
+            'data' => [
+                'foo' => 'baz',
+            ],
+        ];
+
+        $expected = [
+            'foo' => 'baz',
+        ];
+
+        self::assertSame($expected, $this->subject->process($this->contentObjectRenderer, [], $processorConfiguration, $processedData));
+    }
+
+    /**
+     * @return \Generator<string, array{Src\DataProcessing\ProcessorDataSource, array<string, mixed>}>
+     */
+    public static function processAcceptsSingleDataSourceDataProvider(): \Generator
+    {
+        yield 'content object configuration' => [
+            Src\DataProcessing\ProcessorDataSource::ContentObjectConfiguration,
+            ['foo' => 'COC-BAZ'],
+        ];
+        yield 'content object renderer' => [
+            Src\DataProcessing\ProcessorDataSource::ContentObjectRenderer,
+            ['foo' => 'COR-BAZ'],
+        ];
+        yield 'processed data' => [
+            Src\DataProcessing\ProcessorDataSource::ProcessedData,
+            ['foo' => 'PD-BAZ'],
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $expected
+     */
+    #[Framework\Attributes\Test]
+    #[Framework\Attributes\DataProvider('processAcceptsSingleDataSourceDataProvider')]
+    public function processAcceptsSingleDataSource(
+        Src\DataProcessing\ProcessorDataSource $dataSource,
+        array $expected,
+    ): void {
+        $this->contentObjectRenderer->data = [
+            'foo' => 'COR-BAZ',
+        ];
+
+        $contentObjectConfiguration = [
+            'foo' => 'COC-BAZ',
+        ];
+        $processorConfiguration = [
+            'dataSource' => $dataSource->value,
+            'variables.' => [
+                'foo' => 'TEXT',
+                'foo.' => [
+                    'field' => 'foo',
+                ],
+            ],
+        ];
+        $processedData = [
+            'foo' => 'PD-BAZ',
+        ];
+
+        self::assertSame(
+            $expected,
+            $this->subject->process($this->contentObjectRenderer, $contentObjectConfiguration, $processorConfiguration, $processedData),
+        );
+    }
+
+    /**
+     * @return \Generator<string, array{array<int, string>, array<string, mixed>}>
+     */
+    public static function processAcceptsDifferentDataSourcesDataProvider(): \Generator
+    {
+        yield 'no data sources' => [
+            [],
+            [],
+        ];
+        yield 'single data source' => [
+            [Src\DataProcessing\ProcessorDataSource::ContentObjectRenderer->value],
+            ['foo' => 'COR-BAZ'],
+        ];
+        yield 'multiple data sources' => [
+            [
+                30 => 'contentObjectConfiguration:bar',
+                20 => 'contentObjectRenderer',
+                10 => 'processedData',
+            ],
+            ['foo' => 'COC-BAZ'],
+        ];
+    }
+
+    /**
+     * @param array<int, string> $dataSources
+     * @param array<string, mixed> $expected
+     */
+    #[Framework\Attributes\Test]
+    #[Framework\Attributes\DataProvider('processAcceptsDifferentDataSourcesDataProvider')]
+    public function processAcceptsDifferentDataSources(array $dataSources, array $expected): void
+    {
+        $this->contentObjectRenderer->data = [
+            'foo' => 'COR-BAZ',
+        ];
+
+        $contentObjectConfiguration = [
+            'bar.' => [
+                'foo' => 'COC-BAZ',
+            ],
+        ];
+        $processorConfiguration = [
+            'dataSource.' => $dataSources,
+            'variables.' => [
+                'foo' => 'TEXT',
+                'foo.' => [
+                    'field' => 'foo',
+                ],
+            ],
+        ];
+        $processedData = [
+            'foo' => 'PD-BAZ',
+        ];
+
+        self::assertSame(
+            $expected,
+            $this->subject->process($this->contentObjectRenderer, $contentObjectConfiguration, $processorConfiguration, $processedData),
+        );
+    }
+
+    #[Framework\Attributes\Test]
+    public function processLogsUsageOfInvalidDataSourceKeyword(): void
+    {
+        $this->contentObjectRenderer->start(['uid' => 123], 'tt_content');
+
+        $processorConfiguration = [
+            'dataSource' => 'foo',
+        ];
+
+        self::assertSame([], $this->subject->process($this->contentObjectRenderer, [], $processorConfiguration, []));
+
+        self::assertTrue(
+            $this->logger->hasWarning([
+                'message' => 'Invalid processor data source keyword "{source}" passed to "process-variables" data processor (while processing {table}:{uid}).',
+                'context' => [
+                    'source' => 'foo',
+                    'table' => 'tt_content',
+                    'uid' => 123,
+                ],
+            ]),
+        );
+    }
+
+    #[Framework\Attributes\Test]
+    public function processHandlesDataSourcesWithConfiguredPath(): void
+    {
+        $processorConfiguration = [
+            'dataSource' => 'processedData:foo.baz',
+            'variables.' => [
+                'bar' => 'TEXT',
+                'bar.' => [
+                    'field' => 'bar',
+                ],
+            ],
+        ];
+        $processedData = [
+            'foo' => [
+                'baz' => [
+                    'bar' => 'foo',
+                ],
+            ],
+        ];
+
+        $expected = [
+            'bar' => 'foo',
+        ];
+
+        self::assertSame(
+            $expected,
+            $this->subject->process($this->contentObjectRenderer, [], $processorConfiguration, $processedData),
+        );
+    }
+
+    #[Framework\Attributes\Test]
+    public function processLogsUsageOfInvalidDataSourcePath(): void
+    {
+        $this->contentObjectRenderer->start(['uid' => 123], 'tt_content');
+
+        $processorConfiguration = [
+            'dataSource' => 'processedData:foo.bar',
+            'variables.' => [
+                'bar' => 'TEXT',
+                'bar.' => [
+                    'field' => 'bar',
+                ],
+            ],
+        ];
+        $processedData = [
+            'foo' => [
+                'baz' => [
+                    'bar' => 'foo',
+                ],
+            ],
+        ];
+
+        self::assertSame([], $this->subject->process($this->contentObjectRenderer, [], $processorConfiguration, $processedData));
+
+        self::assertTrue(
+            $this->logger->hasWarning([
+                'message' => 'Invalid path "{path}" for processor data source "{source}" passed to "process-variables" data processor (while processing {table}:{uid}).',
+                'context' => [
+                    'path' => 'foo.bar',
+                    'source' => 'processedData',
+                    'table' => 'tt_content',
+                    'uid' => 123,
+                ],
+            ]),
+        );
     }
 
     #[Framework\Attributes\Test]


### PR DESCRIPTION
## About this PR

This PR extends the handling of data processed by the `process-variables` data processor. Until now, only a configured `data` object or, as fallback, either `data` from processed data or `$cObj->data` were taken into account for further processing.

With this PR, it is now possible to explicitly define the data source(s) to use. A new processor configuration option `dataSource` is introduced, which accepts keyword(s) of data sources to use. The following data sources are accepted:

* `contentObjectConfiguration` (reflects `$contentObjectConfiguration`)
* `contentObjectRenderer` (reflects `$cObj->data`)
* `processedData` (reflects `$processedData`)

Using any other keyword will cause in a warning to be logged. It is possible to define either **exactly one keyword** or a **ordered list of keywords**. The latter is processed by priority; each data sources is merged with `ArrayUtility::mergeRecursiveWithOverrule`, allowing additional behavior like the `__unset` option.

In addition, the data source can be limited to a given path. For example, the `processedData` source can be limited to an available `data` object only by defining the data source as `processedData:data`. Nested values should be delimited by a colon, e.g. `processedData:path.to.nested.data`.

## Example

### Single data source

```
hero = HANDLEBARSTEMPLATE
hero {
  templateName = @hero

  # ...

  dataProcessing {
    10 = process-variables
    10 {
      if.isTrue.field = title

      dataSource = contentObjectRenderer

      variables {
        header = TEXT
        header.field = title

        teaser = TEXT
        teaser.field = teaser
        teaser.parseFunc < lib.parseFunc_RTE

        # ...
      }
    }
  }
}
```

### Multiple data sources

```
accordion = HANDLEBARSTEMPLATE
accordion {
  templateName = @accordion

  # ...

  dataProcessing {
    10 = database-query
    10 {
      # ...

      dataProcessing {
        10 = process-variables
        10 {
          table = tx_mysitepackage_domain_model_accordion_element
          as = accordionItem

          dataSources {
            10 = contentObjectRenderer
            20 = processedData
          }

          variables {
            template = @accordion-item

            header = TEXT
            header.field = title

            bodytext = TEXT
            bodytext.field = bodytext
            bodytext.parseFunc < lib.parseFunc_RTE

            # ...
          }
        }
      }
    }
  }
}
```