### PR TITLE
[FEATURE] Allow merging of processed variables

### DIFF
--- a/Classes/DataProcessing/ProcessVariablesProcessor.php
+++ b/Classes/DataProcessing/ProcessVariablesProcessor.php
@@ -20,6 +20,7 @@ namespace CPSIT\Typo3Handlebars\DataProcessing;
 use CPSIT\Typo3Handlebars\Exception;
 use CPSIT\Typo3Handlebars\Renderer;
 use Symfony\Component\DependencyInjection;
+use TYPO3\CMS\Core;
 use TYPO3\CMS\Frontend;
 
 /**
@@ -114,6 +115,7 @@ final readonly class ProcessVariablesProcessor implements Frontend\ContentObject
         $table = $processorConfiguration['table'] ?? $processedData['table'] ?? $cObj->getCurrentTable();
         $variables = $processorConfiguration['variables.'] ?? null;
         $as = $processorConfiguration['as'] ?? null;
+        $merge = (bool)($processorConfiguration['merge'] ?? false);
 
         // Early return if no variables to process are configured
         if (!\is_array($variables)) {
@@ -133,10 +135,18 @@ final readonly class ProcessVariablesProcessor implements Frontend\ContentObject
         $processor = Renderer\Variables\VariablesProcessor::for($cObj);
         $processedVariables = $processor->process($variables);
 
-        // Apply processed variables, either override processed data (if no target variable name is given)
+        // Apply processed variables, either override/merge processed data (if no target variable name is given)
         // or merge with processed data using given target variable name ("as")
         if ($as === null) {
-            $processedData = $processedVariables;
+            if ($merge) {
+                Core\Utility\ArrayUtility::mergeRecursiveWithOverrule($processedData, $processedVariables);
+            } else {
+                $processedData = $processedVariables;
+            }
+        } elseif ($merge) {
+            $processedData[$as] ??= [];
+
+            Core\Utility\ArrayUtility::mergeRecursiveWithOverrule($processedData[$as], $processedVariables);
         } else {
             $processedData[$as] = $processedVariables;
         }

--- a/Tests/Functional/DataProcessing/ProcessVariablesProcessorTest.php
+++ b/Tests/Functional/DataProcessing/ProcessVariablesProcessorTest.php
@@ -135,4 +135,65 @@ final class ProcessVariablesProcessorTest extends TestingFramework\Core\Function
 
         self::assertSame($expected, $this->subject->process($this->contentObjectRenderer, [], $processorConfiguration, $processedData));
     }
+
+    #[Framework\Attributes\Test]
+    public function processMergesProcessedVariablesWithProcessedData(): void
+    {
+        $this->contentObjectRenderer->data = [
+            'foo' => 'baz',
+        ];
+
+        $processorConfiguration = [
+            'merge' => '1',
+            'variables.' => [
+                'foo' => 'TEXT',
+                'foo.' => [
+                    'field' => 'foo',
+                ],
+            ],
+        ];
+        $processedData = [
+            'baz' => 'foo',
+        ];
+
+        $expected = [
+            'baz' => 'foo',
+            'foo' => 'baz',
+        ];
+
+        self::assertSame($expected, $this->subject->process($this->contentObjectRenderer, [], $processorConfiguration, $processedData));
+    }
+
+    #[Framework\Attributes\Test]
+    public function processMergesProcessedVariablesWithTargetVariableInProcessedData(): void
+    {
+        $this->contentObjectRenderer->data = [
+            'foo' => 'baz',
+        ];
+
+        $processorConfiguration = [
+            'as' => 'target',
+            'merge' => '1',
+            'variables.' => [
+                'foo' => 'TEXT',
+                'foo.' => [
+                    'field' => 'foo',
+                ],
+            ],
+        ];
+        $processedData = [
+            'target' => [
+                'baz' => 'foo',
+            ],
+        ];
+
+        $expected = [
+            'target' => [
+                'baz' => 'foo',
+                'foo' => 'baz',
+            ],
+        ];
+
+        self::assertSame($expected, $this->subject->process($this->contentObjectRenderer, [], $processorConfiguration, $processedData));
+    }
 }


### PR DESCRIPTION
The `process-variables` data processor is extended to allow merging processed variables with currently processed data. For this, a new configuration option `merge` is introduced, which defaults to `false`.