### PR TITLE
[BUGFIX] Limit view factory override implementation to certain services

### DIFF
--- a/Classes/DependencyInjection/CompilerPass/HandlebarsViewFactoryPass.php
+++ b/Classes/DependencyInjection/CompilerPass/HandlebarsViewFactoryPass.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "handlebars".
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace CPSIT\Typo3Handlebars\DependencyInjection\CompilerPass;
+
+use CPSIT\Typo3Handlebars\View;
+use Symfony\Component\DependencyInjection;
+
+/**
+ * HandlebarsViewFactoryPass
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-2.0-or-later
+ *
+ * @phpstan-type TargetService array{calls?: array<string, string>, properties?: list<string>}
+ */
+final class HandlebarsViewFactoryPass extends DependencyInjection\Compiler\AbstractRecursivePass
+{
+    private readonly DependencyInjection\Reference $viewFactory;
+
+    /**
+     * @var array<string, TargetService>
+     */
+    private array $targetServices = [];
+
+    public function __construct(string $viewFactoryServiceId = View\HandlebarsViewFactory::class)
+    {
+        $this->viewFactory = new DependencyInjection\Reference($viewFactoryServiceId);
+    }
+
+    public function process(DependencyInjection\ContainerBuilder $container): void
+    {
+        if ($container->has((string)$this->viewFactory)) {
+            parent::process($container);
+        }
+    }
+
+    protected function processValue(mixed $value, bool $isRoot = false): mixed
+    {
+        $value = parent::processValue($value, $isRoot);
+
+        if (!($value instanceof DependencyInjection\Definition)
+            || $this->currentId === null
+            || !$value->isAutowired()
+            || $value->isAbstract()
+            || $value->getClass() === null
+        ) {
+            return $value;
+        }
+
+        $configuration = $this->targetServices[$this->currentId] ?? $this->resolveBaseConfiguration($value->getClass());
+
+        if ($configuration === null) {
+            return $value;
+        }
+
+        foreach ($configuration['calls'] ?? [] as $methodName => $argumentName) {
+            $value->removeMethodCall($methodName);
+            $value->addMethodCall($methodName, [$argumentName => $this->viewFactory]);
+        }
+
+        foreach ($configuration['properties'] ?? [] as $propertyName) {
+            $value->setArgument($propertyName, $this->viewFactory);
+        }
+
+        return $value;
+    }
+
+    /**
+     * @return TargetService|null
+     */
+    private function resolveBaseConfiguration(string $className): ?array
+    {
+        $reflection = $this->container?->getReflectionClass($className, false);
+
+        if ($reflection === null) {
+            return null;
+        }
+
+        $current = $reflection;
+
+        do {
+            if (array_key_exists($current->getName(), $this->targetServices)) {
+                return $this->targetServices[$current->getName()];
+            }
+
+            $current = $current->getParentClass();
+        } while ($current !== false);
+
+        return null;
+    }
+
+    public function addMethodCall(string $serviceId, string $methodName, string $argumentName = '$viewFactory'): self
+    {
+        $this->targetServices[$serviceId] ??= [];
+        $this->targetServices[$serviceId]['calls'] ??= [];
+        $this->targetServices[$serviceId]['calls'][$methodName] = $argumentName;
+
+        return $this;
+    }
+
+    public function addProperty(string $serviceId, string $propertyName = '$viewFactory'): self
+    {
+        $this->targetServices[$serviceId] ??= [];
+        $this->targetServices[$serviceId]['properties'] ??= [];
+        $this->targetServices[$serviceId]['properties'][] = $propertyName;
+
+        return $this;
+    }
+}

--- a/Classes/View/HandlebarsViewFactory.php
+++ b/Classes/View/HandlebarsViewFactory.php
@@ -30,7 +30,7 @@ use TYPO3\CMS\Frontend;
  * @author Elias Häußler <e.haeussler@familie-redlich.de>
  * @license GPL-2.0-or-later
  */
-#[DependencyInjection\Attribute\AsAlias(Core\View\ViewFactoryInterface::class, public: true)]
+#[DependencyInjection\Attribute\Autoconfigure(public: true)]
 final readonly class HandlebarsViewFactory implements Core\View\ViewFactoryInterface
 {
     public function __construct(

--- a/Configuration/Services.php
+++ b/Configuration/Services.php
@@ -20,9 +20,8 @@ namespace CPSIT\Typo3Handlebars\DependencyInjection;
 use CPSIT\Typo3Handlebars\Attribute;
 use CPSIT\Typo3Handlebars\Renderer;
 use Symfony\Component\DependencyInjection;
-use TYPO3\CMS\Fluid;
+use TYPO3\CMS\Extbase;
 use TYPO3\CMS\Frontend;
-use TYPO3\CMS\Seo;
 
 return static function (
     DependencyInjection\ContainerBuilder $container,
@@ -53,19 +52,17 @@ return static function (
         },
     );
 
-    // Make sure various services always receive an instance of FluidViewFactory, because they fail
-    // hard if any other view than FluidViewAdapter is resolved, which cannot be assured when using
-    // our custom HandlebarsViewFactory, as we don't know the exact context.
-    $services = $configurator->services();
-    $fluidViewFactoryReference = new DependencyInjection\Reference(Fluid\View\FluidViewFactory::class);
-    $servicesRequestingFluidViewFactory = [
-        Frontend\ContentObject\FluidTemplateContentObject::class => '$viewFactory',
-        Seo\XmlSitemap\XmlSitemapRenderer::class => '$viewFactory',
-    ];
+    // Make sure various services receive an instance of HandlebarsViewFactory, because they *may*
+    // render Handelbars templates and can easily fall back to Fluid views using the configured
+    // delegate to FluidViewAdapter. All other services must still rely on FluidViewAdapter,
+    // because we cannot safely delegate to FluidViewAdapter in our HandlebarsViewFactory due to
+    // missing knowledge of the exact context (the HandlebarsViewFactory itself cannot decide
+    // whether a Handlebars template actually exists, so the fallback to the FluidViewFactory may
+    // not be triggered in this case, which will fail hard on various services that rely on
+    // FluidViewAdapter being returned by the ViewFactoryInterface implementation).
+    $viewFactoryPass = new CompilerPass\HandlebarsViewFactoryPass();
+    $viewFactoryPass->addMethodCall(Extbase\Mvc\Controller\ActionController::class, 'injectViewFactory');
+    $viewFactoryPass->addProperty(Frontend\ContentObject\PageViewContentObject::class);
 
-    foreach ($servicesRequestingFluidViewFactory as $className => $argumentName) {
-        if (class_exists($className)) {
-            $services->get($className)->arg($argumentName, $fluidViewFactoryReference);
-        }
-    }
+    $container->addCompilerPass($viewFactoryPass, DependencyInjection\Compiler\PassConfig::TYPE_BEFORE_OPTIMIZATION, -100);
 };

--- a/Tests/Unit/DependencyInjection/CompilerPass/HandlebarsViewFactoryPassTest.php
+++ b/Tests/Unit/DependencyInjection/CompilerPass/HandlebarsViewFactoryPassTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "handlebars".
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace CPSIT\Typo3Handlebars\Tests\Unit\DependencyInjection\CompilerPass;
+
+use CPSIT\Typo3Handlebars as Src;
+use CPSIT\Typo3Handlebars\Tests;
+use PHPUnit\Framework;
+use Symfony\Component\DependencyInjection;
+use TYPO3\TestingFramework;
+
+/**
+ * HandlebarsViewFactoryPassTest
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-2.0-or-later
+ */
+#[Framework\Attributes\CoversClass(Src\DependencyInjection\CompilerPass\HandlebarsViewFactoryPass::class)]
+final class HandlebarsViewFactoryPassTest extends TestingFramework\Core\Unit\UnitTestCase
+{
+    private Src\DependencyInjection\CompilerPass\HandlebarsViewFactoryPass $subject;
+    private DependencyInjection\ContainerBuilder $container;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->subject = new Src\DependencyInjection\CompilerPass\HandlebarsViewFactoryPass(Tests\Unit\Fixtures\Classes\View\DummyViewFactory::class);
+        $this->container = $this->createContainer();
+        $this->container->addCompilerPass($this->subject);
+    }
+
+    #[Framework\Attributes\Test]
+    public function processDoesNothingIfViewFactoryServiceIsMissing(): void
+    {
+        $expected = $this->createContainer(false);
+        $expected->compile();
+
+        self::assertFalse($expected->has(Tests\Unit\Fixtures\Classes\View\DummyViewFactory::class));
+
+        $this->container->removeDefinition(Tests\Unit\Fixtures\Classes\View\DummyViewFactory::class);
+        $this->container->compile();
+
+        self::assertEquals($expected->getServiceIds(), $this->container->getServiceIds());
+    }
+
+    #[Framework\Attributes\Test]
+    public function processDoesNothingIfNoTargetServicesWereAdded(): void
+    {
+        $this->container->compile();
+
+        $expected = $this->container->get(Tests\Unit\Fixtures\Classes\DummyConsumingViewFactoryClass::class);
+
+        self::assertInstanceOf(Tests\Unit\Fixtures\Classes\View\CoreViewFactory::class, $expected->viewFactory);
+    }
+
+    #[Framework\Attributes\Test]
+    public function addMethodCallRegistersMethodCallForGivenService(): void
+    {
+        $this->subject->addMethodCall(
+            Tests\Unit\Fixtures\Classes\DummyConsumingViewFactoryClass::class,
+            'setViewFactory',
+        );
+
+        $this->container->compile();
+
+        $expected = $this->container->get(Tests\Unit\Fixtures\Classes\DummyConsumingViewFactoryClass::class);
+
+        self::assertInstanceOf(Tests\Unit\Fixtures\Classes\View\DummyViewFactory::class, $expected->viewFactory);
+    }
+
+    #[Framework\Attributes\Test]
+    public function addMethodCallRegistersMethodCallForGivenBaseService(): void
+    {
+        $this->subject->addMethodCall(
+            Tests\Unit\Fixtures\Classes\DummyAbstractConsumingViewFactoryClass::class,
+            'setViewFactory',
+        );
+
+        $this->container->compile();
+
+        $expected = $this->container->get(Tests\Unit\Fixtures\Classes\DummyConsumingViewFactoryClass::class);
+
+        self::assertInstanceOf(Tests\Unit\Fixtures\Classes\View\DummyViewFactory::class, $expected->viewFactory);
+    }
+
+    #[Framework\Attributes\Test]
+    public function addPropertyRegistersConstructorArgumentForGivenService(): void
+    {
+        $this->subject->addProperty(Tests\Unit\Fixtures\Classes\DummyConsumingViewFactoryClass::class);
+
+        $this->container->compile();
+
+        $expected = $this->container->get(Tests\Unit\Fixtures\Classes\DummyConsumingViewFactoryClass::class);
+
+        self::assertInstanceOf(Tests\Unit\Fixtures\Classes\View\DummyViewFactory::class, $expected->viewFactory);
+    }
+
+    private function createContainer(bool $addViewFactory = true): DependencyInjection\ContainerBuilder
+    {
+        $definition = new DependencyInjection\Definition();
+        $definition->setAutowired(true);
+        $definition->setPublic(true);
+
+        $container = new DependencyInjection\ContainerBuilder();
+        $container->setDefinition(Tests\Unit\Fixtures\Classes\View\ViewFactory::class, clone $definition);
+        $container->setDefinition(Tests\Unit\Fixtures\Classes\View\CoreViewFactory::class, clone $definition);
+        $container->setDefinition(Tests\Unit\Fixtures\Classes\DummyConsumingViewFactoryClass::class, clone $definition);
+        $container->setAlias(Tests\Unit\Fixtures\Classes\View\ViewFactory::class, Tests\Unit\Fixtures\Classes\View\CoreViewFactory::class);
+
+        if ($addViewFactory) {
+            $container->setDefinition(Tests\Unit\Fixtures\Classes\View\DummyViewFactory::class, clone $definition);
+        }
+
+        return $container;
+    }
+}

--- a/Tests/Unit/Fixtures/Classes/DummyAbstractConsumingViewFactoryClass.php
+++ b/Tests/Unit/Fixtures/Classes/DummyAbstractConsumingViewFactoryClass.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "handlebars".
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace CPSIT\Typo3Handlebars\Tests\Unit\Fixtures\Classes;
+
+/**
+ * DummyConsumingViewFactoryClass
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-2.0-or-later
+ * @internal
+ */
+abstract class DummyAbstractConsumingViewFactoryClass
+{
+    public function __construct(
+        public ?View\ViewFactory $viewFactory = null,
+    ) {}
+
+    public function setViewFactory(View\ViewFactory $viewFactory): void
+    {
+        $this->viewFactory = $viewFactory;
+    }
+}

--- a/Tests/Unit/Fixtures/Classes/DummyConsumingViewFactoryClass.php
+++ b/Tests/Unit/Fixtures/Classes/DummyConsumingViewFactoryClass.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "handlebars".
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace CPSIT\Typo3Handlebars\Tests\Unit\Fixtures\Classes;
+
+/**
+ * DummyConsumingViewFactoryClass
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-2.0-or-later
+ * @internal
+ */
+final class DummyConsumingViewFactoryClass extends DummyAbstractConsumingViewFactoryClass {}

--- a/Tests/Unit/Fixtures/Classes/View/CoreViewFactory.php
+++ b/Tests/Unit/Fixtures/Classes/View/CoreViewFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "handlebars".
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace CPSIT\Typo3Handlebars\Tests\Unit\Fixtures\Classes\View;
+
+/**
+ * CoreViewFactory
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-2.0-or-later
+ * @internal
+ */
+final readonly class CoreViewFactory implements ViewFactory {}

--- a/Tests/Unit/Fixtures/Classes/View/DummyViewFactory.php
+++ b/Tests/Unit/Fixtures/Classes/View/DummyViewFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "handlebars".
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace CPSIT\Typo3Handlebars\Tests\Unit\Fixtures\Classes\View;
+
+/**
+ * DummyViewFactory
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-2.0-or-later
+ * @internal
+ */
+final readonly class DummyViewFactory implements ViewFactory {}

--- a/Tests/Unit/Fixtures/Classes/View/ViewFactory.php
+++ b/Tests/Unit/Fixtures/Classes/View/ViewFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "handlebars".
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace CPSIT\Typo3Handlebars\Tests\Unit\Fixtures\Classes\View;
+
+/**
+ * ViewFactory
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-2.0-or-later
+ * @internal
+ */
+interface ViewFactory {}

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -55,12 +55,6 @@ parameters:
 			path: Classes/View/HandlebarsViewFactory.php
 
 		-
-			rawMessage: Class TYPO3\CMS\Seo\XmlSitemap\XmlSitemapRenderer not found.
-			identifier: class.notFound
-			count: 1
-			path: Configuration/Services.php
-
-		-
 			rawMessage: Attribute class PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations does not exist.
 			identifier: attribute.notFound
 			count: 4


### PR DESCRIPTION
For now, only `ActionController::injectViewFactory()` and `PageViewContentObject::__construct()` receive the specific `HandlebarsViewFactory` implementation. All other services still receive TYPO3's default implementation, which resolves to `FluidViewFactory`. This is to avoid conflicts with various renderings where Fluid is still used and sometimes explicit required.

Consumers can still autowire the concrete `HandlebarsViewFactory`, either by using Symfony's autowire capabilities (e.g. the `#[Autowire]` attribute) or by calling the shipped `HandlebarsViewFactoryPass` like follows:

```php
// Configuration/Services.php

return static function (ContainerBuilder $container): void
{
    $viewFactoryPass = new HandlebarsViewFactoryPass();

    $viewFactoryPass->addMethodCall(
        serviceId: MyCustomService::class,
        methodName: 'injectViewFactory',
        argumentName: '$viewFactory',
    );

    $viewFactoryPass->addProperty(
        serviceId: MyOtherService::class,
        propertyName: '$viewFactory',
    );

    $container->addCompilerPass($viewFactoryPass);
};
```