### PR TITLE
[FEATURE] Provide base set

### DIFF
--- a/Configuration/Sets/Base/config.yaml
+++ b/Configuration/Sets/Base/config.yaml
@@ -1,0 +1,2 @@
+name: cpsit/handlebars
+label: 'Handlebars base'

--- a/Configuration/Sets/Base/settings.definitions.yaml
+++ b/Configuration/Sets/Base/settings.definitions.yaml
@@ -1,0 +1,18 @@
+categories:
+  handlebars:
+    label: Handlebars
+  handlebars.view:
+    label: View
+    parent: handlebars
+
+settings:
+  handlebars.view.templateRootPath:
+    label: 'Path to template root (FE)'
+    type: string
+    default: ''
+    category: handlebars.view
+  handlebars.view.partialRootPath:
+    label: 'Path to partial root (FE)'
+    type: string
+    default: ''
+    category: handlebars.view

--- a/Configuration/Sets/Base/setup.typoscript
+++ b/Configuration/Sets/Base/setup.typoscript
@@ -1,0 +1,11 @@
+plugin.tx_handlebars {
+  view {
+    templateRootPaths {
+      10 = {$handlebars.view.templateRootPath}
+    }
+
+    partialRootPaths {
+      10 = {$handlebars.view.partialRootPath}
+    }
+  }
+}


### PR DESCRIPTION
This PR adds a new site set `cpsit/handlebars`, which currently only eases the integration effort for template/partial root paths. It may be extended in the future to include more base configuration.